### PR TITLE
Ensure payment request creation response includes data array

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
@@ -90,6 +90,44 @@ public class PaymentRequestRepository {
 
     @SuppressWarnings("unchecked")
     Map<String, Object> parsed = objectMapper.readValue(json, Map.class);
+
+    // Ensure the response follows the expected structure with a "data" array
+    if (!parsed.containsKey("data")) {
+      Map<String, Object> structured = new java.util.LinkedHashMap<>();
+
+      java.util.Set<String> metaKeys = java.util.Set.of(
+          "type",
+          "title",
+          "message",
+          "success",
+          "code",
+          "status",
+          "errors"
+      );
+
+      java.util.Map<String, Object> dataEntry = new java.util.LinkedHashMap<>();
+
+      for (java.util.Map.Entry<String, Object> entry : parsed.entrySet()) {
+        String key = entry.getKey();
+        Object value = entry.getValue();
+
+        if (metaKeys.contains(key)) {
+          structured.put(key, value);
+        } else {
+          dataEntry.put(key, value);
+        }
+      }
+
+      structured.put(
+          "data",
+          dataEntry.isEmpty()
+              ? java.util.List.of()
+              : java.util.List.of(dataEntry)
+      );
+
+      return structured.isEmpty() ? parsed : structured;
+    }
+
     return parsed;
   }
 


### PR DESCRIPTION
## Summary
- wrap stored procedure response data into a `data` array when missing to match the expected contract
- preserve metadata fields such as type, title, message, and success while relocating payload values under the new structure

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c09b1f388330a82424005c5617be)