### PR TITLE
Fix payment request creation response data aggregation

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
@@ -70,7 +70,7 @@ public class PaymentRequestRepository {
     query.execute();
 
     // 4) Retrieve the JSON response from the stored procedure.
-    List<?> raw = query.getResultList();
+    List<Object> raw = collectStoredProcedureResults(query);
     if (raw.isEmpty()) {
       return Collections.emptyMap();
     }
@@ -406,6 +406,26 @@ public class PaymentRequestRepository {
 
     response.put("data", dataEntries.isEmpty() ? java.util.List.of() : dataEntries);
     return response;
+  }
+
+  private List<Object> collectStoredProcedureResults(StoredProcedureQuery query) {
+    List<Object> allResults = new java.util.ArrayList<>();
+
+    boolean moreResults = true;
+    while (moreResults) {
+      try {
+        List<?> current = query.getResultList();
+        if (current != null && !current.isEmpty()) {
+          allResults.addAll(current);
+        }
+      } catch (IllegalStateException ignored) {
+        query.getUpdateCount();
+      }
+
+      moreResults = query.hasMoreResults();
+    }
+
+    return allResults;
   }
 
   private void addDataFrom(Object source,

--- a/src/test/java/com/monarchsolutions/sms/repository/PaymentRequestRepositoryTest.java
+++ b/src/test/java/com/monarchsolutions/sms/repository/PaymentRequestRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.monarchsolutions.sms.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class PaymentRequestRepositoryTest {
+
+  private PaymentRequestRepository repository;
+  private Method mergeMethod;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    repository = new PaymentRequestRepository();
+    Field objectMapperField = PaymentRequestRepository.class.getDeclaredField("objectMapper");
+    objectMapperField.setAccessible(true);
+    objectMapperField.set(repository, new ObjectMapper());
+
+    mergeMethod = PaymentRequestRepository.class
+        .getDeclaredMethod("mergeCreatePaymentRequestResult", List.class);
+    mergeMethod.setAccessible(true);
+  }
+
+  @Test
+  void mergeResultIncludesStudentsFromJsonPayload() throws Exception {
+    String json = """
+        {"type":"success","title":"created","message":"done","success":true,
+        "data":[{"full_name":"EMILY","payment_request_id":3},{"full_name":"ASHLY","payment_request_id":4}]}
+        """;
+
+    List<Object> raw = List.of(new Object[] { json });
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> response = (Map<String, Object>) mergeMethod.invoke(repository, raw);
+
+    assertEquals("success", response.get("type"));
+    assertTrue(response.containsKey("data"));
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
+    assertEquals(2, data.size());
+    assertEquals("EMILY", data.get(0).get("full_name"));
+    assertEquals(3, data.get(0).get("payment_request_id"));
+  }
+
+  @Test
+  void mergeResultAppendsRowsFromAdditionalResultSets() throws Exception {
+    String json = """
+        {"type":"success","title":"created","message":"done","success":true,"data":[]}
+        """;
+
+    List<Map<String, Object>> secondResultSet = new ArrayList<>();
+    secondResultSet.add(Map.of("full_name", "EMILY", "payment_request_id", 3));
+    secondResultSet.add(Map.of("full_name", "ASHLY", "payment_request_id", 4));
+
+    List<Object> raw = new ArrayList<>();
+    raw.add(new Object[] { json });
+    raw.add(secondResultSet);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> response = (Map<String, Object>) mergeMethod.invoke(repository, raw);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
+    assertFalse(data.isEmpty());
+    assertEquals("EMILY", data.get(0).get("full_name"));
+    assertEquals(4, data.get(1).get("payment_request_id"));
+  }
+}
+


### PR DESCRIPTION
## Summary
- ensure the payment request creation flow reads all stored procedure result sets so created student entries are preserved
- add repository unit tests covering JSON payloads and additional result sets for the merge logic

## Testing
- ./mvnw -q test *(fails: unable to download Maven distribution in the sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c5c5e6148330b3d4ada38572c024)