### PR TITLE
Fix payment request merge to respect nested data

### DIFF
--- a/src/test/java/com/monarchsolutions/sms/repository/PaymentRequestRepositoryTest.java
+++ b/src/test/java/com/monarchsolutions/sms/repository/PaymentRequestRepositoryTest.java
@@ -36,7 +36,10 @@ class PaymentRequestRepositoryTest {
   void mergeResultIncludesStudentsFromJsonPayload() throws Exception {
     String json = """
         {"type":"success","title":"created","message":"done","success":true,
-        "data":[{"full_name":"EMILY","payment_request_id":3},{"full_name":"ASHLY","payment_request_id":4}]}
+        "data":{"mass_upload":true,"created_count":2,"duplicates_count":0,
+        "created":[{"full_name":"EMILY","student_id":10,"register_id":20,"_payment_request_id":3},
+                    {"full_name":"ASHLY","student_id":11,"register_id":21,"_payment_request_id":4}],
+        "duplicates":[]}}
         """;
 
     List<Object> raw = List.of(new Object[] { json });
@@ -48,34 +51,53 @@ class PaymentRequestRepositoryTest {
     assertTrue(response.containsKey("data"));
 
     @SuppressWarnings("unchecked")
-    List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
-    assertEquals(2, data.size());
-    assertEquals("EMILY", data.get(0).get("full_name"));
-    assertEquals(3, data.get(0).get("payment_request_id"));
+    Map<String, Object> data = (Map<String, Object>) response.get("data");
+    assertEquals(true, data.get("mass_upload"));
+    assertEquals(2, data.get("created_count"));
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> created = (List<Map<String, Object>>) data.get("created");
+    assertEquals(2, created.size());
+    assertEquals("EMILY", created.get(0).get("full_name"));
+    assertEquals(10, created.get(0).get("student_id"));
+    assertEquals(20, created.get(0).get("register_id"));
+    assertEquals(3, created.get(0).get("_payment_request_id"));
   }
 
   @Test
   void mergeResultAppendsRowsFromAdditionalResultSets() throws Exception {
     String json = """
-        {"type":"success","title":"created","message":"done","success":true,"data":[]}
+        {"type":"success","title":"created","message":"done","success":true,
+        "data":{"created":[],"duplicates":[]}}
         """;
 
-    List<Map<String, Object>> secondResultSet = new ArrayList<>();
-    secondResultSet.add(Map.of("full_name", "EMILY", "payment_request_id", 3));
-    secondResultSet.add(Map.of("full_name", "ASHLY", "payment_request_id", 4));
+    List<Map<String, Object>> createdRows = new ArrayList<>();
+    createdRows.add(Map.of("full_name", "EMILY", "_payment_request_id", 3));
+    createdRows.add(Map.of("full_name", "ASHLY", "_payment_request_id", 4));
+
+    List<Map<String, Object>> duplicateRows = new ArrayList<>();
+    duplicateRows.add(Map.of("full_name", "PAUL", "_payment_request_id", 9));
 
     List<Object> raw = new ArrayList<>();
     raw.add(new Object[] { json });
-    raw.add(secondResultSet);
+    raw.add(createdRows);
+    raw.add(duplicateRows);
 
     @SuppressWarnings("unchecked")
     Map<String, Object> response = (Map<String, Object>) mergeMethod.invoke(repository, raw);
 
     @SuppressWarnings("unchecked")
-    List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
-    assertFalse(data.isEmpty());
-    assertEquals("EMILY", data.get(0).get("full_name"));
-    assertEquals(4, data.get(1).get("payment_request_id"));
+    Map<String, Object> data = (Map<String, Object>) response.get("data");
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> created = (List<Map<String, Object>>) data.get("created");
+    assertFalse(created.isEmpty());
+    assertEquals("EMILY", created.get(0).get("full_name"));
+    assertEquals(4, created.get(1).get("_payment_request_id"));
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> duplicates = (List<Map<String, Object>>) data.get("duplicates");
+    assertEquals(1, duplicates.size());
+    assertEquals("PAUL", duplicates.get(0).get("full_name"));
   }
 }
 


### PR DESCRIPTION
## Summary
- update mergeCreatePaymentRequestResult to keep counts inside the nested data payload and append created/duplicate rows appropriately
- adjust unit tests to assert the new response shape with counts and created/duplicate details under data

## Testing
- `mvn -q -DskipTests=false test` *(fails: unable to resolve spring-boot-starter-parent 3.4.2 because Maven Central returns 403 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915272058b08330a8a7817dd5d017d1)