### PR TITLE
Add report endpoint to list payment request recurrences

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
@@ -249,10 +249,73 @@ public class ReportsController {
 			return ResponseEntity.ok(page);
 		} catch (Exception e) {
 			return ResponseEntity.badRequest().body(e.getMessage());
-		}
-	}
+                }
+        }
 
-	// Endpoint for retrieving the list of paymentDetails.
+        @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+        @GetMapping("/payment-request-recurrences")
+        public ResponseEntity<?> getPaymentRecurrences(
+                @RequestHeader("Authorization") String authHeader,
+                @RequestParam(required = false) Long school_id,
+                @RequestParam(required = false) Long student_id,
+                @RequestParam(required = false) Long payment_request_id,
+                @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                LocalDate payment_month,
+                @RequestParam(required = false) String pt_name,
+                @RequestParam(required = false) String payment_reference,
+                @RequestParam(required = false) String student_full_name,
+                @RequestParam(required = false) Boolean sc_enabled,
+                @RequestParam(required = false) Boolean u_enabled,
+                @RequestParam(required = false) Boolean g_enabled,
+                @RequestParam(required = false) String grade_group,
+                @RequestParam(defaultValue = "es") String lang,
+                @RequestParam(required = false) String order_by,
+                @RequestParam(required = false) String order_dir,
+                @RequestParam(defaultValue = "0") Integer offset,
+                @RequestParam(defaultValue = "10") Integer limit,
+                @RequestParam(name = "export_all", defaultValue = "false") Boolean exportAll
+        ) {
+                try {
+                        String token       = authHeader.replaceFirst("^Bearer\\s+", "");
+                        Long   tokenUserId = jwtUtil.extractUserId(token);
+                        String role        = jwtUtil.extractUserRole(token);
+
+                        Long effectiveStudentId = student_id;
+                        if ("STUDENT".equalsIgnoreCase(role)) {
+                                GetStudentDetails details =
+                                        studentService.getStudentDetails(tokenUserId, null, lang);
+                                effectiveStudentId = details.getStudentId();
+                        }
+
+                        PageResult<Map<String,Object>> page = reportsService.getPaymentRecurrences(
+                                tokenUserId,
+                                school_id,
+                                effectiveStudentId,
+                                payment_request_id,
+                                payment_month,
+                                pt_name,
+                                payment_reference,
+                                student_full_name,
+                                sc_enabled,
+                                u_enabled,
+                                g_enabled,
+                                grade_group,
+                                lang,
+                                offset,
+                                limit,
+                                exportAll,
+                                order_by,
+                                order_dir
+                        );
+
+                        return ResponseEntity.ok(page);
+                } catch (Exception e) {
+                        return ResponseEntity.badRequest().body(e.getMessage());
+                }
+        }
+
+        // Endpoint for retrieving the list of paymentDetails.
   @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
   @GetMapping("/balance-recharges")
   public ResponseEntity<?> getBalanceRecharges(

--- a/src/main/java/com/monarchsolutions/sms/repository/ReportsRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/ReportsRepository.java
@@ -142,11 +142,11 @@ public class ReportsRepository {
 		return new PageResult<>(content, totalCount, page, size);
 	}
 	
-	public PageResult<Map<String,Object>> getPaymentsPivotReport(
-		Long schoolId,
-		Long studentId,
-		LocalDate startDate,
-		LocalDate endDate,
+        public PageResult<Map<String,Object>> getPaymentsPivotReport(
+                Long schoolId,
+                Long studentId,
+                LocalDate startDate,
+                LocalDate endDate,
 		Boolean groupStatus,
 		Boolean userStatus,
 		String studentFullName,
@@ -229,8 +229,95 @@ public class ReportsRepository {
 			}
 		}
 
-		return new PageResult<>(content, totalCount, page, size);
-	}
+                return new PageResult<>(content, totalCount, page, size);
+        }
+
+        public PageResult<Map<String,Object>> getPaymentRecurrences(
+                Long tokenUserId,
+                Long schoolId,
+                Long studentId,
+                Long paymentRequestId,
+                LocalDate paymentMonth,
+                String ptName,
+                String paymentReference,
+                String studentFullName,
+                Boolean scEnabled,
+                Boolean uEnabled,
+                Boolean gEnabled,
+                String gradeGroup,
+                String lang,
+                String orderBy,
+                String orderDir,
+                Integer offset,
+                Integer limit,
+                boolean exportAll
+        ) throws SQLException {
+                String call = "{CALL getPaymentRecurrences(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)}";
+                List<Map<String,Object>> content = new ArrayList<>();
+                long totalCount = 0;
+
+                try (Connection conn = dataSource.getConnection();
+                        CallableStatement stmt = conn.prepareCall(call)) {
+
+                        int idx = 1;
+                        if (tokenUserId != null) { stmt.setInt(idx++, tokenUserId.intValue()); } else { stmt.setNull(idx++, Types.INTEGER); }
+                        if (schoolId != null) { stmt.setInt(idx++, schoolId.intValue()); } else { stmt.setNull(idx++, Types.INTEGER); }
+                        if (studentId != null) { stmt.setInt(idx++, studentId.intValue()); } else { stmt.setNull(idx++, Types.INTEGER); }
+                        if (paymentRequestId != null) { stmt.setInt(idx++, paymentRequestId.intValue()); } else { stmt.setNull(idx++, Types.INTEGER); }
+
+                        if (paymentMonth != null) { stmt.setDate(idx++, java.sql.Date.valueOf(paymentMonth)); } else { stmt.setNull(idx++, Types.DATE); }
+
+                        stmt.setString(idx++, ptName);
+                        stmt.setString(idx++, paymentReference);
+                        stmt.setString(idx++, studentFullName);
+
+                        if (scEnabled != null) { stmt.setBoolean(idx++, scEnabled); } else { stmt.setNull(idx++, Types.BOOLEAN); }
+                        if (uEnabled != null) { stmt.setBoolean(idx++, uEnabled); } else { stmt.setNull(idx++, Types.BOOLEAN); }
+                        if (gEnabled != null) { stmt.setBoolean(idx++, gEnabled); } else { stmt.setNull(idx++, Types.BOOLEAN); }
+
+                        stmt.setString(idx++, gradeGroup);
+                        stmt.setString(idx++, lang);
+                        stmt.setString(idx++, orderBy);
+                        stmt.setString(idx++, orderDir);
+
+                        if (exportAll) {
+                                stmt.setNull(idx++, Types.INTEGER);
+                                stmt.setNull(idx++, Types.INTEGER);
+                        } else {
+                                if (offset != null) { stmt.setInt(idx++, offset); } else { stmt.setNull(idx++, Types.INTEGER); }
+                                if (limit != null) { stmt.setInt(idx++, limit); } else { stmt.setNull(idx++, Types.INTEGER); }
+                        }
+
+                        stmt.setBoolean(idx++, exportAll);
+
+                        boolean hasRs = stmt.execute();
+                        if (hasRs) {
+                                try (ResultSet rs = stmt.getResultSet()) {
+                                        ResultSetMetaData md = rs.getMetaData();
+                                        int cols = md.getColumnCount();
+                                        while (rs.next()) {
+                                                Map<String,Object> row = new LinkedHashMap<>();
+                                                for (int c = 1; c <= cols; c++) {
+                                                        row.put(md.getColumnLabel(c), rs.getObject(c));
+                                                }
+                                                content.add(row);
+                                        }
+                                }
+                        }
+
+                        if (stmt.getMoreResults()) {
+                                try (ResultSet rs2 = stmt.getResultSet()) {
+                                        if (rs2.next()) {
+                                                totalCount = rs2.getLong(1);
+                                        }
+                                }
+                        }
+                }
+
+                int offsetValue = offset != null ? offset : 0;
+                int limitValue  = limit != null ? limit : content.size();
+                return new PageResult<>(content, totalCount, offsetValue, limitValue);
+        }
 
 	public ReportsRepository(DataSource dataSource, ObjectMapper objectMapper) {
 		this.dataSource     = dataSource;

--- a/src/main/java/com/monarchsolutions/sms/service/ReportsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/ReportsService.java
@@ -118,6 +118,51 @@ public class ReportsService {
     }
 
 
+    @Transactional(readOnly = true)
+    public PageResult<Map<String,Object>> getPaymentRecurrences(
+        Long tokenUserId,
+        Long schoolId,
+        Long studentId,
+        Long paymentRequestId,
+        LocalDate paymentMonth,
+        String ptName,
+        String paymentReference,
+        String studentFullName,
+        Boolean scEnabled,
+        Boolean uEnabled,
+        Boolean gEnabled,
+        String gradeGroup,
+        String lang,
+        int offset,
+        int limit,
+        Boolean exportAll,
+        String orderBy,
+        String orderDir
+    ) throws Exception {
+        boolean exportAllFlag = exportAll != null && exportAll;
+        return reportsRepository.getPaymentRecurrences(
+            tokenUserId,
+            schoolId,
+            studentId,
+            paymentRequestId,
+            paymentMonth,
+            ptName,
+            paymentReference,
+            studentFullName,
+            scEnabled,
+            uEnabled,
+            gEnabled,
+            gradeGroup,
+            lang,
+            orderBy,
+            orderDir,
+            offset,
+            limit,
+            exportAllFlag
+        );
+    }
+
+
 
     @Transactional(readOnly = true)
     public PageResult<Map<String,Object>> getPaymentRequests(


### PR DESCRIPTION
## Summary
- add a reports controller endpoint to fetch payment request recurrence listings with filtering and role-based student resolution
- expose a corresponding service method that delegates to a new repository routine
- implement repository call to execute the getPaymentRecurrences stored procedure and return paged results

## Testing
- ./mvnw -q -DskipTests compile *(fails: wget could not fetch Maven binary from repo.maven.apache.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a7ad03b483308e85abd0e5d7db9f)