### PR TITLE
Add API endpoint for payment request schedule report

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
@@ -315,6 +315,66 @@ public class ReportsController {
                 }
         }
 
+
+        @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+        @GetMapping("/payment-request-schedule")
+        public ResponseEntity<?> getPaymentRequestSchedule(
+                @RequestHeader("Authorization") String authHeader,
+                @RequestParam(required = false) String rule_name,
+                @RequestParam(required = false) Boolean active,
+                @RequestParam(required = false) Long school_id,
+                @RequestParam(required = false) Long group_id,
+                @RequestParam(required = false) Long student_id,
+                @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                LocalDate due_start,
+                @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                LocalDate due_end,
+                @RequestParam(required = false) String global_search,
+                @RequestParam(required = false) String order_by,
+                @RequestParam(required = false) String order_dir,
+                @RequestParam(defaultValue = "0") Integer offset,
+                @RequestParam(defaultValue = "10") Integer limit,
+                @RequestParam(name = "export_all", defaultValue = "false") Boolean exportAll,
+                @RequestParam(defaultValue = "es") String lang
+        ) {
+                try {
+                        String token       = authHeader.replaceFirst("^Bearer\\s+", "");
+                        Long   tokenUserId = jwtUtil.extractUserId(token);
+                        String role        = jwtUtil.extractUserRole(token);
+
+                        Long effectiveStudentId = student_id;
+                        if ("STUDENT".equalsIgnoreCase(role)) {
+                                GetStudentDetails details =
+                                        studentService.getStudentDetails(tokenUserId, null, lang);
+                                effectiveStudentId = details.getStudentId();
+                        }
+
+                        PageResult<Map<String,Object>> page = reportsService.getPaymentRequestSchedule(
+                                tokenUserId,
+                                rule_name,
+                                active,
+                                school_id,
+                                group_id,
+                                effectiveStudentId,
+                                due_start,
+                                due_end,
+                                global_search,
+                                order_by,
+                                order_dir,
+                                offset,
+                                limit,
+                                exportAll,
+                                lang
+                        );
+
+                        return ResponseEntity.ok(page);
+                } catch (Exception e) {
+                        return ResponseEntity.badRequest().body(e.getMessage());
+                }
+        }
+
         // Endpoint for retrieving the list of paymentDetails.
   @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
   @GetMapping("/balance-recharges")

--- a/src/main/java/com/monarchsolutions/sms/service/ReportsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/ReportsService.java
@@ -165,6 +165,45 @@ public class ReportsService {
 
 
     @Transactional(readOnly = true)
+    public PageResult<Map<String,Object>> getPaymentRequestSchedule(
+        Long tokenUserId,
+        String ruleName,
+        Boolean active,
+        Long schoolId,
+        Long groupId,
+        Long studentId,
+        LocalDate dueStart,
+        LocalDate dueEnd,
+        String globalSearch,
+        String orderBy,
+        String orderDir,
+        Integer offset,
+        Integer limit,
+        Boolean exportAll,
+        String lang
+    ) throws Exception {
+        boolean exportAllFlag = exportAll != null && exportAll;
+        return reportsRepository.getPaymentRequestSchedule(
+            tokenUserId,
+            ruleName,
+            active,
+            schoolId,
+            groupId,
+            studentId,
+            dueStart,
+            dueEnd,
+            globalSearch,
+            orderBy,
+            orderDir,
+            offset,
+            limit,
+            exportAllFlag,
+            lang
+        );
+    }
+
+
+    @Transactional(readOnly = true)
     public PageResult<Map<String,Object>> getPaymentRequests(
         Long token_user_id,
         Long student_id,


### PR DESCRIPTION
## Summary
- add a secured reports endpoint that exposes the getPaymentRequestSchedule stored procedure
- route through a new service method and repository call that handles all procedure parameters and pagination metadata

## Testing
- mvn -q -DskipTests package *(fails: Non-resolvable parent POM due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691800a16ba08330b80315755f24c4e2)