### PR TITLE
Add endpoint to schedule payment requests

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/PaymentRequestController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PaymentRequestController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import com.monarchsolutions.sms.dto.catalogs.ScholarLevelsDto;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRecurrenceDTO;
+import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestScheduleDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.StudentPaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.ValidatePaymentRequestExistence;
 import com.monarchsolutions.sms.service.CatalogsService;
@@ -34,7 +35,7 @@ public class PaymentRequestController {
 
     @Autowired
     private JwtUtil jwtUtil;
-    
+
     // Endpoint to create a new group
     @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
     @PostMapping("/create")
@@ -66,6 +67,29 @@ public class PaymentRequestController {
               lang
           );
           return ResponseEntity.ok(response);
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @PostMapping("/schedule")
+    public ResponseEntity<?> createPaymentRequestSchedule(
+        @RequestHeader("Authorization") String authHeader,
+        @RequestParam(required = false) Long school_id,
+        @RequestParam(required = false) Long group_id,
+        @RequestParam(required = false) Long student_id,
+        @RequestBody CreatePaymentRequestScheduleDTO request,
+        @RequestParam(defaultValue = "es") String lang
+    ) throws Exception {
+        String token = authHeader.substring(7);
+        Long tokenUserId = jwtUtil.extractUserId(token);
+        Map<String, Object> response = paymentRequestService.createPaymentRequestSchedule(
+            tokenUserId,
+            school_id,
+            group_id,
+            student_id,
+            request,
+            lang
+        );
+        return ResponseEntity.ok(response);
     }
 
     @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")

--- a/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/CreatePaymentRequestScheduleDTO.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/CreatePaymentRequestScheduleDTO.java
@@ -1,0 +1,124 @@
+package com.monarchsolutions.sms.dto.paymentRequests;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class CreatePaymentRequestScheduleDTO {
+    private Integer    payment_concept_id;
+    private Integer    period_of_time_id;
+    private String     rule_name_es;
+    private String     rule_name_en;
+    private BigDecimal amount;
+    private String     fee_type;
+    private BigDecimal late_fee;
+    private String     late_fee_frequency;
+    private String     interval_count;
+    private String     comments;
+    private LocalDate  start_date;
+    private LocalDate  end_date;
+    private LocalDate  next_due_date;
+
+    public Integer getPayment_concept_id() {
+        return payment_concept_id;
+    }
+
+    public void setPayment_concept_id(Integer payment_concept_id) {
+        this.payment_concept_id = payment_concept_id;
+    }
+
+    public Integer getPeriod_of_time_id() {
+        return period_of_time_id;
+    }
+
+    public void setPeriod_of_time_id(Integer period_of_time_id) {
+        this.period_of_time_id = period_of_time_id;
+    }
+
+    public String getRule_name_es() {
+        return rule_name_es;
+    }
+
+    public void setRule_name_es(String rule_name_es) {
+        this.rule_name_es = rule_name_es;
+    }
+
+    public String getRule_name_en() {
+        return rule_name_en;
+    }
+
+    public void setRule_name_en(String rule_name_en) {
+        this.rule_name_en = rule_name_en;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getFee_type() {
+        return fee_type;
+    }
+
+    public void setFee_type(String fee_type) {
+        this.fee_type = fee_type;
+    }
+
+    public BigDecimal getLate_fee() {
+        return late_fee;
+    }
+
+    public void setLate_fee(BigDecimal late_fee) {
+        this.late_fee = late_fee;
+    }
+
+    public String getLate_fee_frequency() {
+        return late_fee_frequency;
+    }
+
+    public void setLate_fee_frequency(String late_fee_frequency) {
+        this.late_fee_frequency = late_fee_frequency;
+    }
+
+    public String getInterval_count() {
+        return interval_count;
+    }
+
+    public void setInterval_count(String interval_count) {
+        this.interval_count = interval_count;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    public LocalDate getStart_date() {
+        return start_date;
+    }
+
+    public void setStart_date(LocalDate start_date) {
+        this.start_date = start_date;
+    }
+
+    public LocalDate getEnd_date() {
+        return end_date;
+    }
+
+    public void setEnd_date(LocalDate end_date) {
+        this.end_date = end_date;
+    }
+
+    public LocalDate getNext_due_date() {
+        return next_due_date;
+    }
+
+    public void setNext_due_date(LocalDate next_due_date) {
+        this.next_due_date = next_due_date;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRecurrenceDTO;
+import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestScheduleDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.StudentPaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.ValidatePaymentRequestExistence;
 
@@ -70,6 +71,40 @@ public class PaymentRequestRepository {
     query.execute();
 
     // 4) Retrieve the JSON response from the stored procedure.
+    List<Object> raw = collectStoredProcedureResults(query);
+    if (raw.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    return mergeCreatePaymentRequestResult(raw);
+  }
+
+  public Map<String, Object> createPaymentRequestSchedule(Long tokenUserId,
+                                                          Long schoolId,
+                                                          Long groupId,
+                                                          Long studentId,
+                                                          CreatePaymentRequestScheduleDTO request,
+                                                          String lang) throws Exception {
+    String payloadDataJson = objectMapper.writeValueAsString(request);
+
+    StoredProcedureQuery query = entityManager.createStoredProcedureQuery("createPaymentRequestSchedule");
+
+    query.registerStoredProcedureParameter("token_user_id", Long.class, ParameterMode.IN);
+    query.registerStoredProcedureParameter("p_school_id", Long.class, ParameterMode.IN);
+    query.registerStoredProcedureParameter("p_group_id", Long.class, ParameterMode.IN);
+    query.registerStoredProcedureParameter("p_student_id", Long.class, ParameterMode.IN);
+    query.registerStoredProcedureParameter("p_payload", String.class, ParameterMode.IN);
+    query.registerStoredProcedureParameter("lang", String.class, ParameterMode.IN);
+
+    query.setParameter("token_user_id", tokenUserId != null ? tokenUserId.intValue() : null);
+    query.setParameter("p_school_id", schoolId != null ? schoolId.intValue() : null);
+    query.setParameter("p_group_id", groupId != null ? groupId.intValue() : null);
+    query.setParameter("p_student_id", studentId != null ? studentId.intValue() : null);
+    query.setParameter("p_payload", payloadDataJson);
+    query.setParameter("lang", lang);
+
+    query.execute();
+
     List<Object> raw = collectStoredProcedureResults(query);
     if (raw.isEmpty()) {
       return Collections.emptyMap();

--- a/src/main/java/com/monarchsolutions/sms/service/PaymentRequestService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PaymentRequestService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRecurrenceDTO;
+import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestScheduleDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.StudentPaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.ValidatePaymentRequestExistence;
 import com.monarchsolutions.sms.repository.PaymentRequestRepository;
@@ -28,6 +29,25 @@ public class PaymentRequestService {
                                                   String lang) throws Exception {
       // Call the repository method that converts the request to JSON and executes the stored procedure
       return paymentRequestRepository.createPaymentRequest(token_user_id,  school_id, group_id, student_id, request, lang);
+  }
+
+  public Map<String, Object> createPaymentRequestSchedule(Long tokenUserId,
+                                                          Long schoolId,
+                                                          Long groupId,
+                                                          Long studentId,
+                                                          CreatePaymentRequestScheduleDTO request,
+                                                          String lang) throws Exception {
+    if (schoolId == null && groupId == null && studentId == null) {
+      throw new IllegalArgumentException("At least one of school_id, group_id or student_id must be provided");
+    }
+    return paymentRequestRepository.createPaymentRequestSchedule(
+        tokenUserId,
+        schoolId,
+        groupId,
+        studentId,
+        request,
+        lang
+    );
   }
 
   public String createPaymentRecurrence(Long tokenUserId,


### PR DESCRIPTION
## Summary
- add a DTO for scheduling payment request payloads
- expose a secured `/schedule` endpoint to create scheduled payment requests
- connect service and repository layers to call the new `createPaymentRequestSchedule` stored procedure

## Testing
- mvn -q -DskipTests package *(fails: Non-resolvable parent POM due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b08ea90c8330a11e931f86bd90bc)