### PR TITLE
Add nightly job to execute scheduled payment requests

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/SchoolManagementSystemApplication.java
+++ b/src/main/java/com/monarchsolutions/sms/SchoolManagementSystemApplication.java
@@ -2,13 +2,15 @@ package com.monarchsolutions.sms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @EnableMethodSecurity
+@EnableScheduling
 @SpringBootApplication
 public class SchoolManagementSystemApplication {
 
-	public static void main(String[] args) {
+        public static void main(String[] args) {
 		SpringApplication.run(SchoolManagementSystemApplication.class, args);
 	}
 

--- a/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
@@ -1,0 +1,97 @@
+package com.monarchsolutions.sms.dto.paymentRequests;
+
+import java.time.LocalDate;
+
+public class PaymentRequestScheduleRule {
+
+    private Long paymentRequestScheduledId;
+    private Long schoolId;
+    private Long groupId;
+    private Long studentId;
+    private String payload;
+    private LocalDate nextDueDate;
+    private Integer periodOfTimeId;
+    private Integer intervalCount;
+    private LocalDate endDate;
+    private Long createdBy;
+
+    public Long getPaymentRequestScheduledId() {
+        return paymentRequestScheduledId;
+    }
+
+    public void setPaymentRequestScheduledId(Long paymentRequestScheduledId) {
+        this.paymentRequestScheduledId = paymentRequestScheduledId;
+    }
+
+    public Long getSchoolId() {
+        return schoolId;
+    }
+
+    public void setSchoolId(Long schoolId) {
+        this.schoolId = schoolId;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Long groupId) {
+        this.groupId = groupId;
+    }
+
+    public Long getStudentId() {
+        return studentId;
+    }
+
+    public void setStudentId(Long studentId) {
+        this.studentId = studentId;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public LocalDate getNextDueDate() {
+        return nextDueDate;
+    }
+
+    public void setNextDueDate(LocalDate nextDueDate) {
+        this.nextDueDate = nextDueDate;
+    }
+
+    public Integer getPeriodOfTimeId() {
+        return periodOfTimeId;
+    }
+
+    public void setPeriodOfTimeId(Integer periodOfTimeId) {
+        this.periodOfTimeId = periodOfTimeId;
+    }
+
+    public Integer getIntervalCount() {
+        return intervalCount;
+    }
+
+    public void setIntervalCount(Integer intervalCount) {
+        this.intervalCount = intervalCount;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/job/PaymentRequestSchedulerJob.java
+++ b/src/main/java/com/monarchsolutions/sms/job/PaymentRequestSchedulerJob.java
@@ -1,0 +1,23 @@
+package com.monarchsolutions.sms.job;
+
+import java.time.LocalDate;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.monarchsolutions.sms.service.PaymentRequestSchedulerService;
+
+@Component
+public class PaymentRequestSchedulerJob {
+
+    private final PaymentRequestSchedulerService schedulerService;
+
+    public PaymentRequestSchedulerJob(PaymentRequestSchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+
+    @Scheduled(cron = "${jobs.payment-request-scheduler.cron:0 15 2 * * *}")
+    public void runDailyJob() {
+        schedulerService.execute(LocalDate.now());
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
@@ -1,0 +1,112 @@
+package com.monarchsolutions.sms.repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.monarchsolutions.sms.dto.paymentRequests.PaymentRequestScheduleRule;
+
+@Repository
+public class PaymentRequestScheduleRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public PaymentRequestScheduleRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    private static final RowMapper<PaymentRequestScheduleRule> RULE_MAPPER = (rs, rowNum) -> {
+        PaymentRequestScheduleRule rule = new PaymentRequestScheduleRule();
+        rule.setPaymentRequestScheduledId(rs.getLong("payment_request_scheduled_id"));
+        rule.setSchoolId(getLong(rs, "school_id"));
+        rule.setGroupId(getLong(rs, "group_id"));
+        rule.setStudentId(getLong(rs, "student_id"));
+        rule.setPayload(rs.getString("payload"));
+        rule.setNextDueDate(rs.getObject("next_due_date", LocalDate.class));
+        rule.setPeriodOfTimeId(getInteger(rs, "period_of_time_id"));
+        rule.setIntervalCount(getInteger(rs, "interval_count"));
+        rule.setEndDate(rs.getObject("end_date", LocalDate.class));
+        rule.setCreatedBy(getLong(rs, "created_by"));
+        return rule;
+    };
+
+    private static Long getLong(ResultSet rs, String column) throws SQLException {
+        long value = rs.getLong(column);
+        return rs.wasNull() ? null : value;
+    }
+
+    private static Integer getInteger(ResultSet rs, String column) throws SQLException {
+        int value = rs.getInt(column);
+        return rs.wasNull() ? null : value;
+    }
+
+    public List<PaymentRequestScheduleRule> findDueSchedules(LocalDate referenceDate) {
+        String sql = """
+            SELECT
+                payment_request_scheduled_id,
+                school_id,
+                group_id,
+                student_id,
+                payload,
+                next_due_date,
+                period_of_time_id,
+                interval_count,
+                end_date,
+                created_by
+            FROM payment_request_scheduled
+            WHERE active = 1
+              AND next_due_date IS NOT NULL
+              AND next_due_date <= :referenceDate
+              AND (end_date IS NULL OR end_date >= :referenceDate)
+        """;
+
+        Map<String, Object> params = Map.of("referenceDate", referenceDate);
+        return jdbcTemplate.query(sql, params, RULE_MAPPER);
+    }
+
+    public void updateNextDueDate(Long scheduleId, LocalDate nextDueDate) {
+        String sql = """
+            UPDATE payment_request_scheduled
+               SET next_due_date = :nextDueDate,
+                   updated_at = NOW()
+             WHERE payment_request_scheduled_id = :scheduleId
+        """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("nextDueDate", nextDueDate)
+            .addValue("scheduleId", scheduleId);
+
+        jdbcTemplate.update(sql, params);
+    }
+
+    public void deactivate(Long scheduleId) {
+        String sql = """
+            UPDATE payment_request_scheduled
+               SET active = 0,
+                   updated_at = NOW()
+             WHERE payment_request_scheduled_id = :scheduleId
+        """;
+
+        Map<String, Object> params = Map.of("scheduleId", scheduleId);
+        jdbcTemplate.update(sql, params);
+    }
+
+    public void touchExecution(Long scheduleId) {
+        String sql = """
+            UPDATE payment_request_scheduled
+               SET last_executed_at = NOW(),
+                   updated_at = NOW()
+             WHERE payment_request_scheduled_id = :scheduleId
+        """;
+
+        Map<String, Object> params = Map.of("scheduleId", scheduleId);
+        jdbcTemplate.update(sql, params);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/ScheduledJobLogRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/ScheduledJobLogRepository.java
@@ -1,0 +1,95 @@
+package com.monarchsolutions.sms.repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ScheduledJobLogRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public ScheduledJobLogRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public Long insertStarted(String jobName, LocalDateTime executionDate) {
+        String sql = """
+            INSERT INTO scheduled_job_log (
+                job_name,
+                execution_date,
+                status,
+                rules_processed,
+                requests_created,
+                failed_students,
+                duration_ms,
+                error_message,
+                error_stack,
+                metadata
+            ) VALUES (
+                :jobName,
+                :executionDate,
+                'STARTED',
+                0,
+                0,
+                0,
+                NULL,
+                NULL,
+                NULL,
+                NULL
+            )
+        """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("jobName", jobName)
+            .addValue("executionDate", executionDate);
+
+        jdbcTemplate.update(sql, params);
+        return jdbcTemplate.getJdbcTemplate().queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    public void finalizeLog(Long logId,
+                            String status,
+                            int rulesProcessed,
+                            int requestsCreated,
+                            int failedStudents,
+                            Instant startedAt,
+                            String errorMessage,
+                            String errorStack,
+                            String metadataJson) {
+        long durationMs = Duration.between(startedAt, Instant.now()).toMillis();
+
+        String sql = """
+            UPDATE scheduled_job_log
+               SET status = :status,
+                   rules_processed = :rulesProcessed,
+                   requests_created = :requestsCreated,
+                   failed_students = :failedStudents,
+                   duration_ms = :duration,
+                   error_message = :errorMessage,
+                   error_stack = :errorStack,
+                   metadata = :metadata,
+                   created_at = created_at
+             WHERE scheduled_job_log_id = :logId
+        """;
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("status", status);
+        params.put("rulesProcessed", rulesProcessed);
+        params.put("requestsCreated", requestsCreated);
+        params.put("failedStudents", failedStudents);
+        params.put("duration", durationMs);
+        params.put("errorMessage", errorMessage);
+        params.put("errorStack", errorStack);
+        params.put("metadata", metadataJson);
+        params.put("logId", logId);
+
+        jdbcTemplate.update(sql, params);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/PaymentRequestSchedulerService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PaymentRequestSchedulerService.java
@@ -1,0 +1,233 @@
+package com.monarchsolutions.sms.service;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestDTO;
+import com.monarchsolutions.sms.dto.paymentRequests.PaymentRequestScheduleRule;
+import com.monarchsolutions.sms.repository.PaymentRequestScheduleRepository;
+import com.monarchsolutions.sms.repository.ScheduledJobLogRepository;
+
+@Service
+public class PaymentRequestSchedulerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaymentRequestSchedulerService.class);
+    private static final String JOB_NAME = "payment_request_scheduler";
+
+    private final PaymentRequestScheduleRepository scheduleRepository;
+    private final PaymentRequestService paymentRequestService;
+    private final ScheduledJobLogRepository jobLogRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${jobs.payment-request-scheduler.enabled:true}")
+    private boolean enabled;
+
+    @Value("${jobs.payment-request-scheduler.lang:es}")
+    private String defaultLang;
+
+    public PaymentRequestSchedulerService(PaymentRequestScheduleRepository scheduleRepository,
+                                          PaymentRequestService paymentRequestService,
+                                          ScheduledJobLogRepository jobLogRepository,
+                                          ObjectMapper objectMapper) {
+        this.scheduleRepository = scheduleRepository;
+        this.paymentRequestService = paymentRequestService;
+        this.jobLogRepository = jobLogRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void execute(LocalDate referenceDate) {
+        if (!enabled) {
+            LOGGER.debug("{} job is disabled", JOB_NAME);
+            return;
+        }
+
+        Instant startedAt = Instant.now();
+        Long logId = jobLogRepository.insertStarted(JOB_NAME, LocalDateTime.now());
+
+        LocalDate today = referenceDate != null ? referenceDate : LocalDate.now();
+        List<PaymentRequestScheduleRule> rules;
+        try {
+            rules = scheduleRepository.findDueSchedules(today);
+        } catch (Exception ex) {
+            jobLogRepository.finalizeLog(
+                logId,
+                "FAILURE",
+                0,
+                0,
+                0,
+                startedAt,
+                ex.getMessage(),
+                stackTrace(ex),
+                null
+            );
+            throw ex;
+        }
+
+        int processed = 0;
+        int createdRequests = 0;
+        int failedStudents = 0;
+        String errorMessage = null;
+        String errorStack = null;
+        boolean hasFailures = false;
+
+        List<Map<String, Object>> perRuleMetadata = new ArrayList<>();
+
+        for (PaymentRequestScheduleRule rule : rules) {
+            processed++;
+            Map<String, Object> ruleMeta = new HashMap<>();
+            ruleMeta.put("payment_request_scheduled_id", rule.getPaymentRequestScheduledId());
+            ruleMeta.put("school_id", rule.getSchoolId());
+            ruleMeta.put("group_id", rule.getGroupId());
+            ruleMeta.put("student_id", rule.getStudentId());
+            try {
+                CreatePaymentRequestDTO payload = objectMapper.readValue(rule.getPayload(), CreatePaymentRequestDTO.class);
+                Map<String, Object> response = paymentRequestService.createPaymentRequest(
+                    rule.getCreatedBy(),
+                    rule.getSchoolId(),
+                    rule.getGroupId(),
+                    rule.getStudentId(),
+                    payload,
+                    defaultLang
+                );
+
+                Map<String, Object> dataSection = extractDataSection(response);
+                Object massUpload = dataSection.get("mass_upload");
+                ruleMeta.put("mass_upload", massUpload);
+                ruleMeta.put("response", response);
+
+                createdRequests += extractCreatedCount(dataSection);
+                failedStudents += extractFailedCount(dataSection);
+
+                advanceSchedule(rule);
+
+            } catch (Exception ex) {
+                hasFailures = true;
+                if (errorMessage == null) {
+                    errorMessage = ex.getMessage();
+                    errorStack = stackTrace(ex);
+                }
+                ruleMeta.put("error", ex.getMessage());
+                LOGGER.error("Error executing schedule {}", rule.getPaymentRequestScheduledId(), ex);
+            }
+            perRuleMetadata.add(ruleMeta);
+        }
+
+        String metadataJson = null;
+        try {
+            Map<String, Object> metadata = Map.of(
+                "reference_date", today.toString(),
+                "rules", perRuleMetadata
+            );
+            metadataJson = objectMapper.writeValueAsString(metadata);
+        } catch (Exception e) {
+            LOGGER.warn("Unable to serialize job metadata", e);
+        }
+
+        String finalStatus;
+        if (processed == 0 && !hasFailures) {
+            finalStatus = "SUCCESS";
+        } else if (!hasFailures) {
+            finalStatus = "SUCCESS";
+        } else if (processed == 0) {
+            finalStatus = "FAILURE";
+        } else {
+            finalStatus = "PARTIAL_SUCCESS";
+        }
+
+        jobLogRepository.finalizeLog(
+            logId,
+            finalStatus,
+            processed,
+            createdRequests,
+            failedStudents,
+            startedAt,
+            errorMessage,
+            errorStack,
+            metadataJson
+        );
+    }
+
+    private String stackTrace(Exception ex) {
+        StringWriter sw = new StringWriter();
+        ex.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    private void advanceSchedule(PaymentRequestScheduleRule rule) {
+        LocalDate current = rule.getNextDueDate();
+        LocalDate next = calculateNextDueDate(current, rule.getPeriodOfTimeId(), rule.getIntervalCount());
+        if (next == null || (rule.getEndDate() != null && next.isAfter(rule.getEndDate()))) {
+            scheduleRepository.deactivate(rule.getPaymentRequestScheduledId());
+        } else {
+            scheduleRepository.updateNextDueDate(rule.getPaymentRequestScheduledId(), next);
+        }
+        scheduleRepository.touchExecution(rule.getPaymentRequestScheduledId());
+    }
+
+    private LocalDate calculateNextDueDate(LocalDate current, Integer periodOfTimeId, Integer interval) {
+        if (current == null || periodOfTimeId == null) {
+            return null;
+        }
+
+        int steps = interval != null && interval > 0 ? interval : 1;
+        ChronoUnit unit = switch (periodOfTimeId) {
+            case 1 -> ChronoUnit.DAYS;
+            case 2 -> ChronoUnit.WEEKS;
+            case 3 -> ChronoUnit.MONTHS;
+            case 4 -> ChronoUnit.YEARS;
+            default -> ChronoUnit.MONTHS;
+        };
+
+        return current.plus(steps, unit);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractDataSection(Map<String, Object> response) {
+        if (response == null) {
+            return Map.of();
+        }
+        Object data = response.get("data");
+        if (data instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return Map.of();
+    }
+
+    private int extractCreatedCount(Map<String, Object> dataSection) {
+        Object count = dataSection.get("created_count");
+        if (count instanceof Number number) {
+            return number.intValue();
+        }
+        Object created = dataSection.get("created");
+        if (created instanceof List<?> list) {
+            return list.size();
+        }
+        return 0;
+    }
+
+    private int extractFailedCount(Map<String, Object> dataSection) {
+        Object duplicatesCount = dataSection.get("duplicates_count");
+        if (duplicatesCount instanceof Number number) {
+            return number.intValue();
+        }
+        Object duplicates = dataSection.get("duplicates");
+        if (duplicates instanceof List<?> list) {
+            return list.size();
+        }
+        return 0;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,8 @@ app.upload-dir=       C:/xampp/htdocs/sms/var/app/protectedfiles
 app.coffee-dir=       C:/xampp/htdocs/sms/var/app/img/coffee
 app.schools_logos-dir=C:/xampp/htdocs/sms/var/app/img/schools_logos
 app.bulk_files-dir=   C:/xampp/htdocs/sms/var/app/bulkfiles
+
+# Scheduler configuration
+jobs.payment-request-scheduler.enabled=true
+jobs.payment-request-scheduler.cron=0 15 2 * * *
+jobs.payment-request-scheduler.lang=es


### PR DESCRIPTION
## Summary
- enable Spring scheduling and add a nightly job that finds due payment request schedules, calls the existing creation flow, and advances each rule
- persist execution stats and metadata (including mass upload information and the originating schedule id) in the `scheduled_job_log` table
- add repositories, DTOs, and configuration required to read scheduled rules and log executions

## Testing
- Not run (Maven dependencies cannot be downloaded in the current environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e93658e083308797a7599a25cd97)