### PR TITLE
Fix payment request scheduler payload generation

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
@@ -1,5 +1,6 @@
 package com.monarchsolutions.sms.dto.paymentRequests;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public class PaymentRequestScheduleRule {
@@ -8,7 +9,14 @@ public class PaymentRequestScheduleRule {
     private Long schoolId;
     private Long groupId;
     private Long studentId;
-    private String payload;
+    private Long paymentConceptId;
+    private BigDecimal amount;
+    private String feeType;
+    private BigDecimal lateFee;
+    private Integer lateFeeFrequency;
+    private String comments;
+    private String paymentMonth;
+    private Boolean partialPayment;
     private LocalDate nextDueDate;
     private Integer periodOfTimeId;
     private Integer intervalCount;
@@ -47,12 +55,68 @@ public class PaymentRequestScheduleRule {
         this.studentId = studentId;
     }
 
-    public String getPayload() {
-        return payload;
+    public Long getPaymentConceptId() {
+        return paymentConceptId;
     }
 
-    public void setPayload(String payload) {
-        this.payload = payload;
+    public void setPaymentConceptId(Long paymentConceptId) {
+        this.paymentConceptId = paymentConceptId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(String feeType) {
+        this.feeType = feeType;
+    }
+
+    public BigDecimal getLateFee() {
+        return lateFee;
+    }
+
+    public void setLateFee(BigDecimal lateFee) {
+        this.lateFee = lateFee;
+    }
+
+    public Integer getLateFeeFrequency() {
+        return lateFeeFrequency;
+    }
+
+    public void setLateFeeFrequency(Integer lateFeeFrequency) {
+        this.lateFeeFrequency = lateFeeFrequency;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    public String getPaymentMonth() {
+        return paymentMonth;
+    }
+
+    public void setPaymentMonth(String paymentMonth) {
+        this.paymentMonth = paymentMonth;
+    }
+
+    public Boolean getPartialPayment() {
+        return partialPayment;
+    }
+
+    public void setPartialPayment(Boolean partialPayment) {
+        this.partialPayment = partialPayment;
     }
 
     public LocalDate getNextDueDate() {

--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
@@ -28,7 +28,12 @@ public class PaymentRequestScheduleRepository {
         rule.setSchoolId(getLong(rs, "school_id"));
         rule.setGroupId(getLong(rs, "group_id"));
         rule.setStudentId(getLong(rs, "student_id"));
-        rule.setPayload(rs.getString("payload"));
+        rule.setPaymentConceptId(getLong(rs, "payment_concept_id"));
+        rule.setAmount(rs.getBigDecimal("amount"));
+        rule.setFeeType(rs.getString("fee_type"));
+        rule.setLateFee(rs.getBigDecimal("late_fee"));
+        rule.setLateFeeFrequency(getInteger(rs, "late_fee_frequency"));
+        rule.setComments(rs.getString("comments"));
         rule.setNextDueDate(rs.getObject("next_due_date", LocalDate.class));
         rule.setPeriodOfTimeId(getInteger(rs, "period_of_time_id"));
         rule.setIntervalCount(getInteger(rs, "interval_count"));
@@ -54,7 +59,12 @@ public class PaymentRequestScheduleRepository {
                 school_id,
                 group_id,
                 student_id,
-                payload,
+                payment_concept_id,
+                amount,
+                fee_type,
+                late_fee,
+                late_fee_frequency,
+                comments,
                 next_due_date,
                 period_of_time_id,
                 interval_count,


### PR DESCRIPTION
## Summary
- extend the payment request schedule rule to capture the fields needed to build the payment payload
- update the scheduler repository to fetch those fields from `payment_request_scheduled`
- build the payload programmatically in the job instead of relying on a non-existent `payload` column

## Testing
- `mvn -q -DskipTests package` *(fails: cannot download the Spring Boot parent POM from Maven Central in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1093fbe48330bd58def10e77b05b)