### PR TITLE
Update payment request scheduler to use execution date and payment window

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
@@ -17,7 +17,8 @@ public class PaymentRequestScheduleRule {
     private String comments;
     private String paymentMonth;
     private Boolean partialPayment;
-    private LocalDate nextDueDate;
+    private LocalDate nextExecutionDate;
+    private Integer paymentWindow;
     private Integer periodOfTimeId;
     private Integer intervalCount;
     private LocalDate endDate;
@@ -119,12 +120,20 @@ public class PaymentRequestScheduleRule {
         this.partialPayment = partialPayment;
     }
 
-    public LocalDate getNextDueDate() {
-        return nextDueDate;
+    public LocalDate getNextExecutionDate() {
+        return nextExecutionDate;
     }
 
-    public void setNextDueDate(LocalDate nextDueDate) {
-        this.nextDueDate = nextDueDate;
+    public void setNextExecutionDate(LocalDate nextExecutionDate) {
+        this.nextExecutionDate = nextExecutionDate;
+    }
+
+    public Integer getPaymentWindow() {
+        return paymentWindow;
+    }
+
+    public void setPaymentWindow(Integer paymentWindow) {
+        this.paymentWindow = paymentWindow;
     }
 
     public Integer getPeriodOfTimeId() {

--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
@@ -34,7 +34,8 @@ public class PaymentRequestScheduleRepository {
         rule.setLateFee(rs.getBigDecimal("late_fee"));
         rule.setLateFeeFrequency(getInteger(rs, "late_fee_frequency"));
         rule.setComments(rs.getString("comments"));
-        rule.setNextDueDate(rs.getObject("next_due_date", LocalDate.class));
+        rule.setNextExecutionDate(rs.getObject("next_execution_date", LocalDate.class));
+        rule.setPaymentWindow(getInteger(rs, "payment_window"));
         rule.setPeriodOfTimeId(getInteger(rs, "period_of_time_id"));
         rule.setIntervalCount(getInteger(rs, "interval_count"));
         rule.setEndDate(rs.getObject("end_date", LocalDate.class));
@@ -65,15 +66,16 @@ public class PaymentRequestScheduleRepository {
                 late_fee,
                 late_fee_frequency,
                 comments,
-                next_due_date,
+                next_execution_date,
+                payment_window,
                 period_of_time_id,
                 interval_count,
                 end_date,
                 created_by
             FROM payment_request_scheduled
             WHERE active = 1
-              AND next_due_date IS NOT NULL
-              AND next_due_date <= :referenceDate
+              AND next_execution_date IS NOT NULL
+              AND next_execution_date <= :referenceDate
               AND (end_date IS NULL OR end_date >= :referenceDate)
         """;
 
@@ -81,16 +83,16 @@ public class PaymentRequestScheduleRepository {
         return jdbcTemplate.query(sql, params, RULE_MAPPER);
     }
 
-    public void updateNextDueDate(Long scheduleId, LocalDate nextDueDate) {
+    public void updateNextExecutionDate(Long scheduleId, LocalDate nextExecutionDate) {
         String sql = """
             UPDATE payment_request_scheduled
-               SET next_due_date = :nextDueDate,
+               SET next_execution_date = :nextExecutionDate,
                    updated_at = NOW()
              WHERE payment_request_scheduled_id = :scheduleId
         """;
 
         MapSqlParameterSource params = new MapSqlParameterSource()
-            .addValue("nextDueDate", nextDueDate)
+            .addValue("nextExecutionDate", nextExecutionDate)
             .addValue("scheduleId", scheduleId);
 
         jdbcTemplate.update(sql, params);


### PR DESCRIPTION
## Summary
- align payment request scheduling DTO and repository with the `next_execution_date` and `payment_window` fields
- update scheduler logic to advance using execution dates and derive pay-by dates from the payment window

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3af157188330b888e19b46b4be87)