### PR TITLE
Adjust pay-by date using next due date window

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PaymentRequestScheduleRule.java
@@ -18,6 +18,7 @@ public class PaymentRequestScheduleRule {
     private String paymentMonth;
     private Boolean partialPayment;
     private LocalDate nextExecutionDate;
+    private LocalDate nextDueDate;
     private Integer paymentWindow;
     private Integer periodOfTimeId;
     private Integer intervalCount;
@@ -126,6 +127,14 @@ public class PaymentRequestScheduleRule {
 
     public void setNextExecutionDate(LocalDate nextExecutionDate) {
         this.nextExecutionDate = nextExecutionDate;
+    }
+
+    public LocalDate getNextDueDate() {
+        return nextDueDate;
+    }
+
+    public void setNextDueDate(LocalDate nextDueDate) {
+        this.nextDueDate = nextDueDate;
     }
 
     public Integer getPaymentWindow() {

--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestScheduleRepository.java
@@ -35,6 +35,7 @@ public class PaymentRequestScheduleRepository {
         rule.setLateFeeFrequency(getInteger(rs, "late_fee_frequency"));
         rule.setComments(rs.getString("comments"));
         rule.setNextExecutionDate(rs.getObject("next_execution_date", LocalDate.class));
+        rule.setNextDueDate(rs.getObject("next_due_date", LocalDate.class));
         rule.setPaymentWindow(getInteger(rs, "payment_window"));
         rule.setPeriodOfTimeId(getInteger(rs, "period_of_time_id"));
         rule.setIntervalCount(getInteger(rs, "interval_count"));
@@ -67,6 +68,7 @@ public class PaymentRequestScheduleRepository {
                 late_fee_frequency,
                 comments,
                 next_execution_date,
+                next_due_date,
                 payment_window,
                 period_of_time_id,
                 interval_count,

--- a/src/main/java/com/monarchsolutions/sms/service/PaymentRequestSchedulerService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PaymentRequestSchedulerService.java
@@ -95,7 +95,7 @@ public class PaymentRequestSchedulerService {
             ruleMeta.put("group_id", rule.getGroupId());
             ruleMeta.put("student_id", rule.getStudentId());
             try {
-                CreatePaymentRequestDTO payload = buildPayload(rule, today);
+                CreatePaymentRequestDTO payload = buildPayload(rule);
                 Map<String, Object> response = paymentRequestService.createPaymentRequest(
                     rule.getCreatedBy(),
                     rule.getSchoolId(),
@@ -196,11 +196,11 @@ public class PaymentRequestSchedulerService {
         return current.plus(steps, unit);
     }
 
-    private CreatePaymentRequestDTO buildPayload(PaymentRequestScheduleRule rule, LocalDate executionDate) {
+    private CreatePaymentRequestDTO buildPayload(PaymentRequestScheduleRule rule) {
         CreatePaymentRequestDTO dto = new CreatePaymentRequestDTO();
         dto.setPayment_concept_id(toInteger(rule.getPaymentConceptId()));
         dto.setAmount(rule.getAmount());
-        dto.setPay_by(calculatePayBy(executionDate, rule.getPaymentWindow()));
+        dto.setPay_by(calculatePayBy(rule.getNextDueDate(), rule.getPaymentWindow()));
         dto.setComments(rule.getComments());
         dto.setLate_fee(rule.getLateFee());
         dto.setFee_type(rule.getFeeType());
@@ -234,9 +234,9 @@ public class PaymentRequestSchedulerService {
         return formatter.format(firstDayOfMonth);
     }
 
-    private LocalDate calculatePayBy(LocalDate executionDate, Integer paymentWindow) {
+    private LocalDate calculatePayBy(LocalDate dueDate, Integer paymentWindow) {
         int windowDays = paymentWindow != null ? paymentWindow : 0;
-        LocalDate baseDate = executionDate != null ? executionDate : LocalDate.now();
+        LocalDate baseDate = dueDate != null ? dueDate : LocalDate.now();
         return baseDate.plusDays(windowDays);
     }
 


### PR DESCRIPTION
## Summary
- add support for next due date in scheduled payment rule mapping
- calculate pay-by date using the rule's next due date plus the payment window
- include next due date column in scheduled payment query

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3eee0d648330ba8dc4deb1c80951)