### PR TITLE
Handle closed statement when iterating stored procedure results

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PaymentRequestRepository.java
@@ -481,7 +481,14 @@ public class PaymentRequestRepository {
         query.getUpdateCount();
       }
 
-      moreResults = query.hasMoreResults();
+      try {
+        moreResults = query.hasMoreResults();
+      } catch (Exception ex) {
+        // Some JDBC drivers may close the statement after the last result set,
+        // which causes hasMoreResults() to throw (e.g. "statement closed").
+        // Treat that as the end of the results stream.
+        moreResults = false;
+      }
     }
 
     return allResults;


### PR DESCRIPTION
## Summary
- handle exceptions from hasMoreResults when JDBC closes the statement after consuming stored procedure results
- ensure stored procedure result collection stops gracefully instead of failing automatic jobs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b62427a3c833089ccf04ee90ee45d)