### PR TITLE
Add endpoint to fetch scheduled job logs

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/LogsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/LogsController.java
@@ -1,6 +1,7 @@
 package com.monarchsolutions.sms.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -77,12 +78,31 @@ public class LogsController {
         Long token_user_id = jwtUtil.extractUserId(token);
 
         List<PaymentLogGroupDto> grouped = UserLogsService.getGroupedPaymentLogs(
-            token_user_id,    
+            token_user_id,
             schoolId,
             paymentId,
             lang
         );
         return ResponseEntity.ok(grouped);
+    }
+
+    // Endpoint to retrieve scheduled job logs from stored procedure getScheduledJobLogs
+    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @GetMapping("/scheduled-jobs")
+    public ResponseEntity<List<Map<String, Object>>> getScheduledJobLogs(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestParam(name = "payment_request_scheduled_id", required = false) Long paymentRequestScheduledId,
+            @RequestParam(defaultValue = "es") String lang
+    ) {
+        String token = authHeader.substring(7);
+        Long tokenUserId = jwtUtil.extractUserId(token);
+
+        List<Map<String, Object>> logs = UserLogsService.getScheduledJobLogs(
+                tokenUserId,
+                paymentRequestScheduledId,
+                lang
+        );
+        return ResponseEntity.ok(logs);
     }
 
 }

--- a/src/main/java/com/monarchsolutions/sms/service/LogsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/LogsService.java
@@ -89,12 +89,12 @@ public class LogsService {
 	}
 
 	// ---------------------------------------
-	public List<PaymentLogGroupDto> getGroupedPaymentLogs(
-		Long token_user_id,
-		Long tokenSchoolId,
-		Long paymentId,
-		String lang
-	) {
+        public List<PaymentLogGroupDto> getGroupedPaymentLogs(
+                Long token_user_id,
+                Long tokenSchoolId,
+                Long paymentId,
+                String lang
+        ) {
 		// 1) Fetch the flat list of row‐level logs
 		List<PaymentLogsDto> flat = logsRepository.getPaymentLogs(
 			token_user_id,tokenSchoolId, paymentId, lang
@@ -144,7 +144,15 @@ public class LogsService {
 
 		// **HERE** re-sort your grouped list by updated_at descending
 		grouped.sort(Comparator.comparing(PaymentLogGroupDto::getUpdated_at).reversed());
-	
-		return grouped;
-	}
+
+                return grouped;
+        }
+
+        public List<Map<String, Object>> getScheduledJobLogs(
+                Long tokenUserId,
+                Long paymentRequestScheduledId,
+                String lang
+        ) {
+                return logsRepository.getScheduledJobLogs(tokenUserId, paymentRequestScheduledId, lang);
+        }
 }


### PR DESCRIPTION
## Summary
- add repository support to call the `getScheduledJobLogs` stored procedure and parse its JSON output
- expose service and controller methods to retrieve scheduled payment request job logs for authenticated admins

## Testing
- mvn -q -DskipTests compile *(fails: missing access to Spring Boot parent POM, HTTP 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691babf7e4288330ac79f0c4de20cea8)