### PR TITLE
Add dynamic DB-backed permission authorization

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/annotation/RequirePermission.java
+++ b/src/main/java/com/monarchsolutions/sms/annotation/RequirePermission.java
@@ -1,0 +1,31 @@
+package com.monarchsolutions.sms.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declarative permission guard that maps an endpoint to a module/action pair
+ * stored in the database. Example usage:
+ *
+ * <pre>
+ *     @RequirePermission(module = "students", action = "r")
+ *     @GetMapping("/students/list")
+ *     public List<StudentDTO> getStudents() { ... }
+ * </pre>
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequirePermission {
+
+    /**
+     * Module key, e.g. "students", "payments", "finance".
+     */
+    String module();
+
+    /**
+     * CRUD action: c (create), r (read), u (update), d (delete).
+     */
+    String action();
+}

--- a/src/main/java/com/monarchsolutions/sms/config/SecurityConfig.java
+++ b/src/main/java/com/monarchsolutions/sms/config/SecurityConfig.java
@@ -24,14 +24,11 @@ public class SecurityConfig {
         .cors(withDefaults())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/login").permitAll()
-                .requestMatchers("/api/users/admin/**").hasRole("ADMIN")
-                .requestMatchers("/api/schools/admin/**").hasRole("ADMIN")
-                .requestMatchers("/api/users/school_admin/**").hasRole("SCHOOL_ADMIN")
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .httpBasic(Customizer.withDefaults());
-        
+
         return http.build();
     }
 }

--- a/src/main/java/com/monarchsolutions/sms/config/WebConfig.java
+++ b/src/main/java/com/monarchsolutions/sms/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.monarchsolutions.sms.config;
+
+import com.monarchsolutions.sms.filter.PermissionInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final PermissionInterceptor permissionInterceptor;
+
+    public WebConfig(PermissionInterceptor permissionInterceptor) {
+        this.permissionInterceptor = permissionInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(permissionInterceptor).addPathPatterns("/**");
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/controller/PermissionDemoController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PermissionDemoController.java
@@ -1,0 +1,24 @@
+package com.monarchsolutions.sms.controller;
+
+import com.monarchsolutions.sms.annotation.RequirePermission;
+import com.monarchsolutions.sms.dto.permission.StudentDTO;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/permission-demo")
+public class PermissionDemoController {
+
+    @RequirePermission(module = "students", action = "r")
+    @GetMapping("/students/list")
+    public ResponseEntity<List<StudentDTO>> getStudents() {
+        List<StudentDTO> sampleStudents = List.of(
+                new StudentDTO(1L, "Ada Lovelace", "ada@example.com"),
+                new StudentDTO(2L, "Alan Turing", "alan@example.com")
+        );
+        return ResponseEntity.ok(sampleStudents);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/dto/permission/StudentDTO.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/permission/StudentDTO.java
@@ -1,0 +1,40 @@
+package com.monarchsolutions.sms.dto.permission;
+
+public class StudentDTO {
+    private Long id;
+    private String fullName;
+    private String email;
+
+    public StudentDTO() {
+    }
+
+    public StudentDTO(Long id, String fullName, String email) {
+        this.id = id;
+        this.fullName = fullName;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/entity/Module.java
+++ b/src/main/java/com/monarchsolutions/sms/entity/Module.java
@@ -1,0 +1,59 @@
+package com.monarchsolutions.sms.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "modules")
+public class Module {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "module_id")
+    private Long moduleId;
+
+    @Column(name = "key", nullable = false, unique = true, length = 100)
+    private String key;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
+    public Long getModuleId() {
+        return moduleId;
+    }
+
+    public void setModuleId(Long moduleId) {
+        this.moduleId = moduleId;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/entity/Permission.java
+++ b/src/main/java/com/monarchsolutions/sms/entity/Permission.java
@@ -1,0 +1,97 @@
+package com.monarchsolutions.sms.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "permissions")
+public class Permission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "permission_id")
+    private Long permissionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "module_id", nullable = false)
+    private Module module;
+
+    @Column(name = "can_create")
+    private boolean canCreate;
+
+    @Column(name = "can_read")
+    private boolean canRead;
+
+    @Column(name = "can_update")
+    private boolean canUpdate;
+
+    @Column(name = "can_delete")
+    private boolean canDelete;
+
+    public Long getPermissionId() {
+        return permissionId;
+    }
+
+    public void setPermissionId(Long permissionId) {
+        this.permissionId = permissionId;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    public Module getModule() {
+        return module;
+    }
+
+    public void setModule(Module module) {
+        this.module = module;
+    }
+
+    public boolean isCanCreate() {
+        return canCreate;
+    }
+
+    public void setCanCreate(boolean canCreate) {
+        this.canCreate = canCreate;
+    }
+
+    public boolean isCanRead() {
+        return canRead;
+    }
+
+    public void setCanRead(boolean canRead) {
+        this.canRead = canRead;
+    }
+
+    public boolean isCanUpdate() {
+        return canUpdate;
+    }
+
+    public void setCanUpdate(boolean canUpdate) {
+        this.canUpdate = canUpdate;
+    }
+
+    public boolean isCanDelete() {
+        return canDelete;
+    }
+
+    public void setCanDelete(boolean canDelete) {
+        this.canDelete = canDelete;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/entity/Role.java
+++ b/src/main/java/com/monarchsolutions/sms/entity/Role.java
@@ -1,0 +1,48 @@
+package com.monarchsolutions.sms.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_id")
+    private Long roleId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
+    public Long getRoleId() {
+        return roleId;
+    }
+
+    public void setRoleId(Long roleId) {
+        this.roleId = roleId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/filter/PermissionInterceptor.java
+++ b/src/main/java/com/monarchsolutions/sms/filter/PermissionInterceptor.java
@@ -1,0 +1,96 @@
+package com.monarchsolutions.sms.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monarchsolutions.sms.annotation.RequirePermission;
+import com.monarchsolutions.sms.service.PermissionService;
+import com.monarchsolutions.sms.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class PermissionInterceptor implements HandlerInterceptor {
+
+    private final PermissionService permissionService;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    public PermissionInterceptor(PermissionService permissionService, JwtUtil jwtUtil, ObjectMapper objectMapper) {
+        this.permissionService = permissionService;
+        this.jwtUtil = jwtUtil;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        RequirePermission requirePermission = findAnnotation(handlerMethod);
+        if (requirePermission == null) {
+            return true;
+        }
+
+        String token = resolveToken(request);
+        if (!StringUtils.hasText(token)) {
+            writeError(response, HttpStatus.UNAUTHORIZED, "Missing or invalid Authorization header");
+            return false;
+        }
+
+        if (!jwtUtil.validateToken(token)) {
+            writeError(response, HttpStatus.UNAUTHORIZED, "Invalid or expired token");
+            return false;
+        }
+
+        Long roleId = jwtUtil.extractRoleId(token);
+        if (roleId == null) {
+            writeError(response, HttpStatus.UNAUTHORIZED, "Token does not contain role_id");
+            return false;
+        }
+
+        boolean allowed = permissionService.hasPermission(roleId, requirePermission.module(), requirePermission.action());
+        if (!allowed) {
+            String message = String.format("Role %d lacks '%s' permission on module '%s'", roleId, requirePermission.action(), requirePermission.module());
+            writeError(response, HttpStatus.FORBIDDEN, message);
+            return false;
+        }
+
+        return true;
+    }
+
+    private RequirePermission findAnnotation(HandlerMethod handlerMethod) {
+        RequirePermission methodAnn = handlerMethod.getMethodAnnotation(RequirePermission.class);
+        if (methodAnn != null) {
+            return methodAnn;
+        }
+        return handlerMethod.getBeanType().getAnnotation(RequirePermission.class);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String headerAuth = request.getHeader("Authorization");
+        if (StringUtils.hasText(headerAuth) && headerAuth.startsWith("Bearer ")) {
+            return headerAuth.substring(7);
+        }
+        return null;
+    }
+
+    private void writeError(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/ModuleRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/ModuleRepository.java
@@ -1,0 +1,11 @@
+package com.monarchsolutions.sms.repository;
+
+import com.monarchsolutions.sms.entity.Module;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ModuleRepository extends JpaRepository<Module, Long> {
+    Optional<Module> findByKey(String key);
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/PermissionRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PermissionRepository.java
@@ -1,0 +1,11 @@
+package com.monarchsolutions.sms.repository;
+
+import com.monarchsolutions.sms.entity.Permission;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PermissionRepository extends JpaRepository<Permission, Long> {
+    Optional<Permission> findByRole_RoleIdAndModule_ModuleId(Long roleId, Long moduleId);
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/RoleEntityRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/RoleEntityRepository.java
@@ -1,0 +1,9 @@
+package com.monarchsolutions.sms.repository;
+
+import com.monarchsolutions.sms.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleEntityRepository extends JpaRepository<Role, Long> {
+}

--- a/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
@@ -1,0 +1,56 @@
+package com.monarchsolutions.sms.service;
+
+import com.monarchsolutions.sms.entity.Module;
+import com.monarchsolutions.sms.entity.Permission;
+import com.monarchsolutions.sms.repository.ModuleRepository;
+import com.monarchsolutions.sms.repository.PermissionRepository;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PermissionService {
+
+    private final PermissionRepository permissionRepository;
+    private final ModuleRepository moduleRepository;
+
+    public PermissionService(PermissionRepository permissionRepository, ModuleRepository moduleRepository) {
+        this.permissionRepository = permissionRepository;
+        this.moduleRepository = moduleRepository;
+    }
+
+    /**
+     * Check whether the role has permission to perform an action on a module.
+     *
+     * @param roleId    role identifier coming from JWT
+     * @param moduleKey logical module key (e.g., students, payments)
+     * @param action    CRUD action (c, r, u, d)
+     * @return true if permission exists and is enabled
+     */
+    @Transactional(readOnly = true)
+    public boolean hasPermission(Long roleId, String moduleKey, String action) {
+        if (roleId == null || moduleKey == null || action == null) {
+            return false;
+        }
+
+        Optional<Module> module = moduleRepository.findByKey(moduleKey);
+        if (module.isEmpty()) {
+            return false;
+        }
+
+        Optional<Permission> permission = permissionRepository.findByRole_RoleIdAndModule_ModuleId(roleId, module.get().getModuleId());
+        if (permission.isEmpty()) {
+            return false;
+        }
+
+        String normalizedAction = action.toLowerCase(Locale.ROOT);
+        return switch (normalizedAction) {
+            case "c" -> permission.get().isCanCreate();
+            case "r" -> permission.get().isCanRead();
+            case "u" -> permission.get().isCanUpdate();
+            case "d" -> permission.get().isCanDelete();
+            default -> false;
+        };
+    }
+}

--- a/src/main/resources/db/permissions-schema.sql
+++ b/src/main/resources/db/permissions-schema.sql
@@ -1,0 +1,27 @@
+-- Roles table
+CREATE TABLE roles (
+    role_id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100),
+    description VARCHAR(255)
+);
+
+-- Modules table
+CREATE TABLE modules (
+    module_id INT AUTO_INCREMENT PRIMARY KEY,
+    `key` VARCHAR(100) UNIQUE,
+    name VARCHAR(100),
+    description VARCHAR(255)
+);
+
+-- Permissions table
+CREATE TABLE permissions (
+    permission_id INT AUTO_INCREMENT PRIMARY KEY,
+    role_id INT NOT NULL,
+    module_id INT NOT NULL,
+    can_create BOOL DEFAULT 0,
+    can_read   BOOL DEFAULT 0,
+    can_update BOOL DEFAULT 0,
+    can_delete BOOL DEFAULT 0,
+    FOREIGN KEY (role_id) REFERENCES roles(role_id),
+    FOREIGN KEY (module_id) REFERENCES modules(module_id)
+);

--- a/src/main/resources/permissions-guide.md
+++ b/src/main/resources/permissions-guide.md
@@ -1,0 +1,55 @@
+# Dynamic permission authorization (JWT + DB)
+
+## SQL bootstrap
+The schema for roles/modules/permissions is stored in `db/permissions-schema.sql` and matches:
+
+```sql
+roles(role_id, name, description)
+modules(module_id, key, name, description)
+permissions(permission_id, role_id, module_id, can_create, can_read, can_update, can_delete)
+```
+
+## JWT payload example
+The backend expects `roleId` in the token claims (in addition to other fields). A sample payload looks like:
+
+```json
+{
+  "sub": "user@example.com",
+  "role": "FINANCE",
+  "roleId": 3,
+  "userId": 42,
+  "schoolId": 7,
+  "iat": 1710000000,
+  "exp": 1710604800
+}
+```
+
+## Custom annotation
+Annotate controllers or methods with `@RequirePermission(module = "students", action = "r")`. The `action` field accepts `c`, `r`, `u`, `d` and maps to the CRUD flags in the `permissions` table.
+
+## Interceptor behavior
+1. Extracts the Bearer token from the `Authorization` header.
+2. Uses `jwtUtil.extractRoleId(token)` to obtain `role_id`.
+3. Loads the module by `key` and validates the matching permission row.
+4. Returns HTTP **403 Forbidden** with a JSON body when the role does not have the required action for the module. Missing/expired tokens return **401 Unauthorized**.
+
+Example 403 response:
+
+```json
+{
+  "timestamp": "2024-01-01T12:00:00Z",
+  "status": 403,
+  "error": "Forbidden",
+  "message": "Role 3 lacks 'u' permission on module 'payments'"
+}
+```
+
+## End-to-end flow demo
+* Endpoint: `@RequirePermission(module = "payments", action = "u")`
+* Token: contains `"roleId": 3`
+* Database: permissions row for role **3** and module **payments** has `can_update = 0`
+
+Result: interceptor answers with **403 Forbidden** and the JSON body shown above.
+
+## Extending to record-level permissions (optional)
+You can extend `PermissionService` to accept an additional resource identifier and look it up in a new table that stores `role_id`, `module_id`, `resource_id`, and CRUD flags. The interceptor would pass the resource id (from path variable or request attribute) to the service and deny access if the specific row is missing.


### PR DESCRIPTION
## Summary
- add @RequirePermission annotation, DTO demo controller, and Web MVC interceptor to enforce permissions from database
- introduce JPA entities/repositories/service for roles, modules, and permissions along with schema/docs and example JWT payload
- simplify security chain to rely on JWT authentication plus dynamic permission interceptor

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve parent POM because Maven Central returned 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927cf9c248483308f175a245bde07da)