### PR TITLE
Replace PreAuthorize with dynamic permissions on balance and classes

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/BalanceController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/BalanceController.java
@@ -1,5 +1,6 @@
 package com.monarchsolutions.sms.controller;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.BalanceService;
 import com.monarchsolutions.sms.util.JwtUtil;
 
@@ -9,7 +10,6 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import com.monarchsolutions.sms.dto.balance.CreateBalanceRechargeDTO;
@@ -32,7 +32,7 @@ public class BalanceController {
   }
 
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
+  @RequirePermission(module = "balances", action = "c")
   @PostMapping("/recharge")
   public ResponseEntity<String> recharge(
       @RequestHeader("Authorization") String authHeader,
@@ -55,7 +55,7 @@ public class BalanceController {
   }
 
   // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
+  @RequirePermission(module = "balances", action = "r")
   @GetMapping("/account-activity")
   public ResponseEntity<?> getBalanceRecharges(
     @RequestHeader("Authorization") String authHeader,
@@ -96,7 +96,7 @@ public class BalanceController {
     }
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "balances", action = "r")
   @GetMapping("/account-activity-grouped")
   public ResponseEntity<List<YearlyActivityDto>> getAccountActivityGroup(
       @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -1,5 +1,6 @@
 package com.monarchsolutions.sms.controller;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.catalogs.PaymentConceptsDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentStatusesDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentThroughDto;
@@ -16,6 +17,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/catalog")
+@RequirePermission(module = "catalogs", action = "r")
 public class CatalogController {
   @Autowired
   private CatalogsService CatalogsService;

--- a/src/main/java/com/monarchsolutions/sms/controller/ClassController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ClassController.java
@@ -4,9 +4,9 @@ import java.util.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.common.PageResult;
 import com.monarchsolutions.sms.service.ClassService;
 import com.monarchsolutions.sms.util.JwtUtil;
@@ -22,7 +22,7 @@ public class ClassController {
   private JwtUtil jwtUtil;
 
   // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "classes", action = "r")
   @GetMapping("")
   public ResponseEntity<?> getClasses(
     @RequestHeader("Authorization") String authHeader,


### PR DESCRIPTION
## Summary
- remove role-based @PreAuthorize checks from balance endpoints in favor of dynamic permission guard
- rely on dynamic permission requirement for class listing endpoint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d1b12cc48330a7a606a97d1fd07b)