### PR TITLE
Switch controllers to dynamic permission annotations

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/BalanceController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/BalanceController.java
@@ -1,20 +1,16 @@
 package com.monarchsolutions.sms.controller;
 
-import com.monarchsolutions.sms.service.BalanceService;
-import com.monarchsolutions.sms.util.JwtUtil;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
-
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.balance.CreateBalanceRechargeDTO;
 import com.monarchsolutions.sms.dto.balance.YearlyActivityDto;
 import com.monarchsolutions.sms.dto.common.PageResult;
+import com.monarchsolutions.sms.service.BalanceService;
+import com.monarchsolutions.sms.util.JwtUtil;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/balances")
@@ -32,7 +28,7 @@ public class BalanceController {
   }
 
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
+  @RequirePermission(module = "balances", action = "c")
   @PostMapping("/recharge")
   public ResponseEntity<String> recharge(
       @RequestHeader("Authorization") String authHeader,
@@ -55,7 +51,7 @@ public class BalanceController {
   }
 
   // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
+  @RequirePermission(module = "balances", action = "r")
   @GetMapping("/account-activity")
   public ResponseEntity<?> getBalanceRecharges(
     @RequestHeader("Authorization") String authHeader,
@@ -96,7 +92,7 @@ public class BalanceController {
     }
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "balances", action = "r")
   @GetMapping("/account-activity-grouped")
   public ResponseEntity<List<YearlyActivityDto>> getAccountActivityGroup(
       @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -1,5 +1,6 @@
 package com.monarchsolutions.sms.controller;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.catalogs.PaymentConceptsDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentStatusesDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentThroughDto;
@@ -7,15 +8,14 @@ import com.monarchsolutions.sms.dto.catalogs.PeriodOfTimeDto;
 import com.monarchsolutions.sms.dto.catalogs.ScholarLevelsDto;
 import com.monarchsolutions.sms.service.CatalogsService;
 import com.monarchsolutions.sms.util.JwtUtil;
-
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/catalog")
+@RequirePermission(module = "catalogs", action = "r")
 public class CatalogController {
   @Autowired
   private CatalogsService CatalogsService;

--- a/src/main/java/com/monarchsolutions/sms/controller/ClassController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ClassController.java
@@ -1,15 +1,13 @@
 package com.monarchsolutions.sms.controller;
 
-import java.util.*;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
-
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.common.PageResult;
 import com.monarchsolutions.sms.service.ClassService;
 import com.monarchsolutions.sms.util.JwtUtil;
+import java.util.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/classes")
@@ -22,7 +20,7 @@ public class ClassController {
   private JwtUtil jwtUtil;
 
   // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "classes", action = "r")
   @GetMapping("")
   public ResponseEntity<?> getClasses(
     @RequestHeader("Authorization") String authHeader,


### PR DESCRIPTION
## Summary
- replace @PreAuthorize annotations in balance and class controllers with RequirePermission
- guard catalog endpoints with the dynamic permission annotation for catalog reads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927df6f2ae48330b7b6eb895630794c)