### PR TITLE
Replace @PreAuthorize with dynamic permission checks

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/CoffeeController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CoffeeController.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +25,7 @@ import com.monarchsolutions.sms.dto.coffee.ProcessCoffeeSaleDTO;
 import com.monarchsolutions.sms.dto.coffee.SaleGroupDTO;
 import com.monarchsolutions.sms.dto.coffee.UpdateCoffeeMenuDTO;
 import com.monarchsolutions.sms.dto.common.PageResult;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.CoffeeService;
 import com.monarchsolutions.sms.util.JwtUtil;
 import org.springframework.util.StringUtils;
@@ -44,7 +44,7 @@ public class CoffeeController {
     this.jwtUtil = jwtUtil;
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "coffee", action = "r")
   @GetMapping("/my-purchases")
   public ResponseEntity<List<SaleGroupDTO>> getMyPurchases(
       @RequestHeader("Authorization") String authHeader,
@@ -58,7 +58,7 @@ public class CoffeeController {
   }
 
   // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "coffee", action = "r")
   @GetMapping("/menu")
   public ResponseEntity<?> getCoffeeMenu(
     @RequestHeader("Authorization") String authHeader,
@@ -97,7 +97,7 @@ public class CoffeeController {
   }
 
   // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
+  @RequirePermission(module = "coffee", action = "r")
   @GetMapping("/sales")
   public ResponseEntity<?> getCoffeeSales(
     @RequestHeader("Authorization") String authHeader,
@@ -147,7 +147,7 @@ public class CoffeeController {
   }
 
   // Endpoint to update an existing group.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "coffee", action = "u")
   @PutMapping(
     path     = "/update/{menu_id}",
     produces = MediaType.APPLICATION_JSON_VALUE
@@ -206,7 +206,7 @@ public class CoffeeController {
   }
 
   // Endpoint to toggle or change the group's status.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "coffee", action = "u")
   @PostMapping("/update/{menu_id}/status")
   public ResponseEntity<String> changeMenuStatus( @RequestHeader("Authorization") String authHeader,
                                                   @PathVariable("menu_id") Long menu_id,
@@ -221,7 +221,7 @@ public class CoffeeController {
     }
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "coffee", action = "r")
   @GetMapping("/{menuId}")
   public ResponseEntity<CoffeeMenuDTO> getMenu(
       @RequestHeader("Authorization") String authHeader,
@@ -241,7 +241,7 @@ public class CoffeeController {
    * POST /api/coffee-sales/process?lang=es
    * Body = { userId:123, items:[{menuId:1,quantity:2},…] }
    */
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "coffee", action = "c")
   @PostMapping(
     path = "/process",
     consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -273,7 +273,7 @@ public class CoffeeController {
     }
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "coffee", action = "c")
   @PostMapping(
     path     = "/create",
     consumes = MediaType.MULTIPART_FORM_DATA_VALUE,

--- a/src/main/java/com/monarchsolutions/sms/controller/FilesController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/FilesController.java
@@ -15,12 +15,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.SchoolService;
 import com.monarchsolutions.sms.util.JwtUtil;
 
@@ -47,7 +47,7 @@ public class FilesController {
   @Autowired
   private JwtUtil jwtUtil;
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/protectedfiles/{filename:.+}")
   public ResponseEntity<Resource> serveProtectedFile(
       @PathVariable String filename,
@@ -127,7 +127,7 @@ public class FilesController {
   //   }
   // }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/school-logo/{school_id}")
   public ResponseEntity<Resource> serveSchoolLogoFile(
       @RequestHeader("Authorization") String authHeader,
@@ -176,7 +176,7 @@ public class FilesController {
     }
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/coffee-menu-image/{filename:.+}")
   public ResponseEntity<Resource> serveCoffeeMenuImage(
       @PathVariable String filename,
@@ -215,7 +215,7 @@ public class FilesController {
     }
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/bulkfile/{filename:.+}")
   public ResponseEntity<Resource> serveBulkFiles(
       @PathVariable String filename,

--- a/src/main/java/com/monarchsolutions/sms/controller/GroupController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/GroupController.java
@@ -4,12 +4,12 @@ import com.monarchsolutions.sms.dto.groups.CreateGroupRequest;
 import com.monarchsolutions.sms.dto.groups.GetClassesCatalog;
 import com.monarchsolutions.sms.dto.groups.GroupsListResponse;
 import com.monarchsolutions.sms.dto.groups.UpdateGroupRequest;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.GroupService;
 import com.monarchsolutions.sms.util.JwtUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,7 +25,7 @@ public class GroupController {
     private JwtUtil jwtUtil;
 
     // Endpoint for retrieving the list of groups.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "classes", action = "r")
     @GetMapping("/list")
     public ResponseEntity<?> getGroupsList( @RequestHeader("Authorization") String authHeader,
                                             @RequestParam(required = false) Long school_id,
@@ -42,7 +42,7 @@ public class GroupController {
     }
     
         // Endpoint to create a new group
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "classes", action = "c")
     @PostMapping("/create")
     public ResponseEntity<String> createGroup(@RequestHeader("Authorization") String authHeader,
                                              @RequestParam(defaultValue = "es") String lang,
@@ -61,7 +61,7 @@ public class GroupController {
     }
 
     // Endpoint to update an existing group.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "classes", action = "u")
     @PutMapping("/update/{group_id}")
     public ResponseEntity<String> updateGroup(@RequestHeader("Authorization") String authHeader,
                                              @PathVariable("group_id") Long group_id,
@@ -82,7 +82,7 @@ public class GroupController {
     }
 
     // Endpoint to toggle or change the group's status.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "classes", action = "u")
     @PostMapping("/update/{group_id}/status")
     public ResponseEntity<String> changeGroupStatus( @RequestHeader("Authorization") String authHeader,
                                                     @RequestParam(defaultValue = "es") String lang,
@@ -97,7 +97,7 @@ public class GroupController {
         }
     }
 	
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+        @RequirePermission(module = "classes", action = "r")
     @GetMapping("/catalog")
     public ResponseEntity<List<GetClassesCatalog>> getClassesCatalog(
         @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/LogsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/LogsController.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import com.monarchsolutions.sms.util.JwtUtil;
 import com.monarchsolutions.sms.dto.userLogs.UserLogsListDto;
@@ -13,6 +12,7 @@ import com.monarchsolutions.sms.dto.userLogs.paymentRequest.PaymentRequestLogGro
 import com.monarchsolutions.sms.dto.userLogs.paymentRequest.PaymentRequestLogsDto;
 import com.monarchsolutions.sms.dto.userLogs.payments.PaymentLogGroupDto;
 import com.monarchsolutions.sms.dto.userLogs.payments.PaymentLogsDto;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.LogsService;
 
 @RestController
@@ -26,7 +26,7 @@ public class LogsController {
     private JwtUtil jwtUtil;
     
     // Endpoint for retrieving the list of usersLogs.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/list")
     public ResponseEntity<?> getUsersActivityLog(
                                         // @RequestHeader("Authorization") String authHeader,
@@ -43,7 +43,7 @@ public class LogsController {
     }
 
     // Endpoint for retrieving the list of paymentRequestLogs.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/payment-requests/{paymentRequestId}")
     public ResponseEntity<List<PaymentRequestLogGroupDto>> getPaymentRequestLogs(
             @RequestHeader("Authorization") String authHeader,
@@ -65,7 +65,7 @@ public class LogsController {
     }
     
     // Endpoint for retrieving the list of paymentLogs.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/payment/{paymentId}")
     public ResponseEntity<List<PaymentLogGroupDto>> getPaymentLogs(
             @RequestHeader("Authorization") String authHeader,
@@ -87,7 +87,7 @@ public class LogsController {
     }
 
     // Endpoint to retrieve scheduled job logs from stored procedure getScheduledJobLogs
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/scheduled-jobs")
     public ResponseEntity<List<Map<String, Object>>> getScheduledJobLogs(
             @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/PaymentController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PaymentController.java
@@ -1,15 +1,18 @@
 package com.monarchsolutions.sms.controller;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.Path;
-import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -18,32 +21,23 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.monarchsolutions.sms.dto.payments.CreatePayment;
-import com.monarchsolutions.sms.dto.payments.UpdatePaymentDTO;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.payments.ByYearPaymentsDTO;
+import com.monarchsolutions.sms.dto.payments.CreatePayment;
+import com.monarchsolutions.sms.dto.payments.UpdatePaymentDTO;
 import com.monarchsolutions.sms.service.PaymentService;
 import com.monarchsolutions.sms.util.JwtUtil;
 import com.monarchsolutions.sms.validation.AdminGroup;
 import com.monarchsolutions.sms.validation.SchoolAdminGroup;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.UUID;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.util.StringUtils;
-import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.ConstraintViolation;
 
@@ -65,7 +59,7 @@ public class PaymentController {
   @Autowired
   private JwtUtil jwtUtil;
   
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "payments", action = "c")
   @PostMapping(
     path = "/create",
     consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
@@ -150,7 +144,7 @@ public class PaymentController {
         .body(jsonResult);
   };
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "payments", action = "c")
   @PostMapping(
     path     = "/create/bulk",
     consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -211,7 +205,7 @@ public class PaymentController {
   }
 
   // Endpoint to update an existing user.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "payments", action = "u")
   @PutMapping(
     path     = "/update/{payment_id}",
     produces = MediaType.APPLICATION_JSON_VALUE
@@ -252,7 +246,7 @@ public class PaymentController {
   }
 
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+  @RequirePermission(module = "payments", action = "r")
   @GetMapping("/grouped")
   public ResponseEntity<List<ByYearPaymentsDTO>> getGroupedPayments(
       @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/PaymentRequestController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PaymentRequestController.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import com.monarchsolutions.sms.dto.catalogs.ScholarLevelsDto;
@@ -19,6 +18,7 @@ import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRecurrenceDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestScheduleDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.StudentPaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.ValidatePaymentRequestExistence;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.CatalogsService;
 import com.monarchsolutions.sms.service.PaymentRequestSchedulerService;
 import com.monarchsolutions.sms.service.PaymentRequestService;
@@ -42,7 +42,7 @@ public class PaymentRequestController {
     private JwtUtil jwtUtil;
 
     // Endpoint to create a new group
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "payment_requests", action = "c")
     @PostMapping("/create")
     public ResponseEntity<?> createPaymentRequest(
       @RequestHeader("Authorization") String authHeader,
@@ -74,7 +74,7 @@ public class PaymentRequestController {
           return ResponseEntity.ok(response);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "payment_requests", action = "c")
     @PostMapping("/create-schedule")
     public ResponseEntity<?> createPaymentRequestSchedule(
         @RequestHeader("Authorization") String authHeader,
@@ -97,7 +97,7 @@ public class PaymentRequestController {
         return ResponseEntity.ok(response);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "payment_requests", action = "r")
     @GetMapping("/schedule/details")
     public ResponseEntity<Map<String, Object>> getPaymentRequestScheduleDetails(
         @RequestHeader("Authorization") String authHeader,
@@ -114,7 +114,7 @@ public class PaymentRequestController {
         return ResponseEntity.ok(details);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "payment_requests", action = "c")
     @PostMapping("/recurrence")
     public ResponseEntity<String> createPaymentRecurrence(
         @RequestHeader("Authorization") String authHeader,
@@ -127,7 +127,7 @@ public class PaymentRequestController {
         return ResponseEntity.ok(json);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "payment_requests", action = "r")
     @GetMapping("/validate-existence")
     public ResponseEntity<List<ValidatePaymentRequestExistence>> validatePaymentRequests(
         @RequestHeader("Authorization") String authHeader,
@@ -165,7 +165,7 @@ public class PaymentRequestController {
         return ResponseEntity.ok(results);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+    @RequirePermission(module = "payment_requests", action = "r")
     @GetMapping("/pending")
     public ResponseEntity<BigDecimal> getPendingByStudent(
         @RequestHeader("Authorization") String authHeader,
@@ -178,7 +178,7 @@ public class PaymentRequestController {
         return ResponseEntity.ok(pending);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+    @RequirePermission(module = "payment_requests", action = "r")
     @GetMapping("/student-pending-payments")
     public ResponseEntity<List<StudentPaymentRequestDTO>> list(
         @RequestHeader("Authorization") String authHeader,
@@ -203,7 +203,7 @@ public class PaymentRequestController {
         return ResponseEntity.ok(list);
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "payment_requests", action = "u")
     @PostMapping("/trigger-scheduler")
     public ResponseEntity<?> triggerPaymentRequestScheduler(
         @RequestParam(required = false, name = "reference_date") String referenceDateParam


### PR DESCRIPTION
## Summary
- replace legacy @PreAuthorize checks with RequirePermission in Files, Group, Coffee, Logs, Payment, and PaymentRequest controllers
- map each endpoint to the appropriate module/action pair to leverage dynamic authorization

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928f2714aa8833081cb841c1d6ecb0e)