### PR TITLE
Replace PreAuthorize with dynamic permissions

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
@@ -18,8 +18,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import com.monarchsolutions.sms.annotation.RequirePermission;
 
 
 @RestController
@@ -36,9 +37,9 @@ public class ReportsController {
 	private JwtUtil jwtUtil;
 	
 	// Endpoint to retrieve the payments pivot report.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
-	@GetMapping("/payments/report")
-	public ResponseEntity<?> getPaymentsPivotReport(
+        @RequirePermission(module = "finance", action = "r")
+        @GetMapping("/payments/report")
+        public ResponseEntity<?> getPaymentsPivotReport(
 		@RequestHeader("Authorization") String authHeader,
 		@RequestParam(required = false) Long student_id,
 		@RequestParam(required = false) Long payment_id,
@@ -104,9 +105,9 @@ public class ReportsController {
 	}
 
 	// Endpoint for retrieving the list of paymentDetails.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN', 'STUDENT')")
-	@GetMapping("/payments")
-	public ResponseEntity<?> getPayments(
+        @RequirePermission(module = "finance", action = "r")
+        @GetMapping("/payments")
+        public ResponseEntity<?> getPayments(
 		@RequestHeader("Authorization") String authHeader,
 		@RequestParam(required = false) Long school_id,
 		@RequestParam(required = false) Long student_id,
@@ -165,9 +166,9 @@ public class ReportsController {
 	// Endpoint for retrieving the list of paymentDetails.
 	
 	// Endpoint to retrieve the payments pivot report.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
-	@GetMapping("/paymentrequests")
-	public ResponseEntity<?> getPaymentRequests(
+        @RequirePermission(module = "finance", action = "r")
+        @GetMapping("/paymentrequests")
+        public ResponseEntity<?> getPaymentRequests(
 		@RequestHeader("Authorization") String authHeader,
 		@RequestParam(required = false) Long student_id,
 		@RequestParam(required = false) Long school_id,
@@ -252,7 +253,7 @@ public class ReportsController {
                 }
         }
 
-        @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+        @RequirePermission(module = "finance", action = "r")
         @GetMapping("/payment-request-recurrences")
         public ResponseEntity<?> getPaymentRecurrences(
                 @RequestHeader("Authorization") String authHeader,
@@ -316,7 +317,7 @@ public class ReportsController {
         }
 
 
-        @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+        @RequirePermission(module = "finance", action = "r")
         @GetMapping("/payment-request-schedule")
         public ResponseEntity<?> getPaymentRequestSchedule(
                 @RequestHeader("Authorization") String authHeader,
@@ -376,7 +377,7 @@ public class ReportsController {
         }
 
         // Endpoint for retrieving the list of paymentDetails.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE','STUDENT')")
+  @RequirePermission(module = "finance", action = "r")
   @GetMapping("/balance-recharges")
   public ResponseEntity<?> getBalanceRecharges(
     @RequestHeader("Authorization") String authHeader,
@@ -423,9 +424,9 @@ public class ReportsController {
     }
   }
 
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
-	@GetMapping("/paymentrequest/details")
-	public ResponseEntity<?> getPaymentRequestDetails(
+        @RequirePermission(module = "finance", action = "r")
+        @GetMapping("/paymentrequest/details")
+        public ResponseEntity<?> getPaymentRequestDetails(
 		@RequestHeader("Authorization") String authHeader,
 		@RequestParam Long payment_request_id,
 		@RequestParam(defaultValue="es") String lang
@@ -447,9 +448,9 @@ public class ReportsController {
 	}
 
 	// Endpoint to update an existing user.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@PutMapping("/payment-request/update/{id}")
-	public ResponseEntity<?> updatePaymentRequest(
+        @RequirePermission(module = "finance", action = "u")
+        @PutMapping("/payment-request/update/{id}")
+        public ResponseEntity<?> updatePaymentRequest(
 		@PathVariable("id") Long paymentRequestId,
 		@RequestHeader("Authorization") String authHeader,
 		@RequestBody UpdatePaymentRequest body,

--- a/src/main/java/com/monarchsolutions/sms/controller/RoleController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/RoleController.java
@@ -5,9 +5,9 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import com.monarchsolutions.sms.util.JwtUtil;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 
 import com.monarchsolutions.sms.dto.roles.RolesListResponse;
 import com.monarchsolutions.sms.service.RoleService;
@@ -23,7 +23,7 @@ public class RoleController {
     private JwtUtil jwtUtil;
 
     // Endpoint for retrieving the list of roles.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "roles", action = "r")
     @GetMapping("")
     public ResponseEntity<?> getRoles(@RequestParam(defaultValue = "es") String lang,
                                       @RequestParam(defaultValue = "1") int role_level,

--- a/src/main/java/com/monarchsolutions/sms/controller/ScholarLevelController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ScholarLevelController.java
@@ -1,5 +1,6 @@
 package com.monarchsolutions.sms.controller;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.common.ScholarLevelsDTO;
 import com.monarchsolutions.sms.service.ScholarLevelService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ public class ScholarLevelController {
     @Autowired
     private ScholarLevelService scholarLevelService;
 
+    @RequirePermission(module = "scholar_levels", action = "r")
     @GetMapping("/list")
     public ResponseEntity<List<ScholarLevelsDTO>> getScholarLevels(@RequestParam(defaultValue = "es") String lang) {
         List<ScholarLevelsDTO> responses = scholarLevelService.getScholarLevels(lang);

--- a/src/main/java/com/monarchsolutions/sms/controller/SchoolController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/SchoolController.java
@@ -10,10 +10,11 @@ import com.monarchsolutions.sms.service.SchoolService;
 import com.monarchsolutions.sms.util.JwtUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.monarchsolutions.sms.annotation.RequirePermission;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -28,9 +29,9 @@ public class SchoolController {
 	private JwtUtil jwtUtil;
 
 	// Endpoint to create a new school
-	@PreAuthorize("hasAnyRole('ADMIN')")
-	@PostMapping("/create")
-	public ResponseEntity<String> createSchool(@RequestBody CreateSchoolRequest request) {
+        @RequirePermission(module = "schools", action = "c")
+        @PostMapping("/create")
+        public ResponseEntity<String> createSchool(@RequestBody CreateSchoolRequest request) {
 		try {
 			// Call the service method (which will pass the JSON data to the SP)
 			String jsonResponse = schoolService.createSchool(request);
@@ -41,9 +42,9 @@ public class SchoolController {
 	}
 
 	// Endpoint for retrieving the list of schools.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@GetMapping("/list")
-	public ResponseEntity<?> getSchoolsList(@RequestHeader("Authorization") String authHeader,
+        @RequirePermission(module = "schools", action = "r")
+        @GetMapping("/list")
+        public ResponseEntity<?> getSchoolsList(@RequestHeader("Authorization") String authHeader,
 											@RequestParam(required = false) Long school_id,
 											@RequestParam(defaultValue = "es") String lang,
 											@RequestParam(defaultValue = "-1") int status_filter) {
@@ -60,9 +61,9 @@ public class SchoolController {
 	}
 
 	// Endpoint for retrieving the list of related schools for a specific shcool.
-	@PreAuthorize("hasAnyRole('ADMIN')")
-	@GetMapping("/listRelated")
-	public ResponseEntity<?> getRelatedSchoolList(@RequestHeader("Authorization") String authHeader,
+        @RequirePermission(module = "schools", action = "r")
+        @GetMapping("/listRelated")
+        public ResponseEntity<?> getRelatedSchoolList(@RequestHeader("Authorization") String authHeader,
 											@RequestParam(required = false) Long school_id,
 											@RequestParam(defaultValue = "es") String lang) {
 		try {
@@ -76,9 +77,9 @@ public class SchoolController {
 	}
 	
 	// Endpoint to update an existing school.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@PutMapping(
-		path     = "/update/{school_id}",
+        @RequirePermission(module = "schools", action = "u")
+        @PutMapping(
+                path     = "/update/{school_id}",
 		produces = MediaType.APPLICATION_JSON_VALUE
 	)
 	public ResponseEntity<?> updateSchool(
@@ -132,9 +133,9 @@ public class SchoolController {
 
 
 	// Endpoint to toggle or change the user's status.
-	@PreAuthorize("hasAnyRole('ADMIN')")
-	@PostMapping("/update/{school_id}/status")
-	public ResponseEntity<String> changeUserStatus(@PathVariable("school_id") Long school_id,
+        @RequirePermission(module = "schools", action = "u")
+        @PostMapping("/update/{school_id}/status")
+        public ResponseEntity<String> changeUserStatus(@PathVariable("school_id") Long school_id,
 													@RequestParam(defaultValue = "es") String lang,
 													@RequestHeader("Authorization") String authHeader) {
 		try {
@@ -148,9 +149,9 @@ public class SchoolController {
 		}
 	}
 
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
-	@GetMapping("/school-image")
-	public ResponseEntity<String> getSchoolImage(
+        @RequirePermission(module = "schools", action = "r")
+        @GetMapping("/school-image")
+        public ResponseEntity<String> getSchoolImage(
 		@RequestHeader("Authorization") String authHeader,
 		@RequestParam(required = false) Long school_id
 	) {

--- a/src/main/java/com/monarchsolutions/sms/controller/StudentController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/StudentController.java
@@ -17,8 +17,9 @@ import jakarta.validation.Validator;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import com.monarchsolutions.sms.annotation.RequirePermission;
 
 import java.util.Set;
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ public class StudentController {
     private ObjectMapper objectMapper;
 
     // Endpoint to create a new user
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "students", action = "c")
     @PostMapping("/create")
     public ResponseEntity<String> createStudent(@RequestBody Object payload,
                                             @RequestHeader("Authorization") String authHeader,
@@ -92,7 +93,7 @@ public class StudentController {
     }
 
     // Endpoint for retrieving the list of students.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "students", action = "r")
     @GetMapping("")
     public ResponseEntity<?> getStudentsList(
         @RequestHeader("Authorization") String authHeader,
@@ -137,7 +138,7 @@ public class StudentController {
     }
 
     // Endpoint to update an existing user.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+    @RequirePermission(module = "students", action = "u")
     @PutMapping("/update/{user_id}")
     public ResponseEntity<String> updateStudent(@RequestBody UpdateStudentRequest request,
                                              @RequestHeader("Authorization") String authHeader,
@@ -172,7 +173,7 @@ public class StudentController {
     }
 
     // Endpoint for retrieving the list of related schools for a specific shcool.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+    @RequirePermission(module = "students", action = "r")
     @GetMapping("/student-details/{student_id}")
     public ResponseEntity<?> getStudent(@RequestHeader("Authorization") String authHeader,
                                         @PathVariable(required = true) Long student_id,
@@ -188,7 +189,7 @@ public class StudentController {
     }
 
     // Endpoint for retrieving the list of related schools for a specific shcool.
-    @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','STUDENT')")
+    @RequirePermission(module = "students", action = "r")
     @GetMapping("/read-only")
     public ResponseEntity<?> getStudentDetails(@RequestHeader("Authorization") String authHeader,
                                         @RequestParam(required = false) Long student_id,
@@ -203,7 +204,7 @@ public class StudentController {
         }
     }
 	
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+        @RequirePermission(module = "students", action = "r")
     @GetMapping("/validate-exist")
     public ResponseEntity<List<ValidateStudentExist>> validateStudentExists(
         @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/TeacherController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/TeacherController.java
@@ -2,8 +2,9 @@ package com.monarchsolutions.sms.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import com.monarchsolutions.sms.annotation.RequirePermission;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +37,7 @@ public class TeacherController {
   @Autowired
   private JwtUtil jwtUtil;
   // Endpoint for retrieving the list of teachers.
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+  @RequirePermission(module = "teachers", action = "r")
   @GetMapping("")
   public ResponseEntity<?> getTeachersList(
       @RequestHeader("Authorization") String authHeader,
@@ -77,9 +78,9 @@ public class TeacherController {
   }
 
   // Endpoint to create a new user or multiple users.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@PostMapping("/create")
-	public ResponseEntity<?> createTeacher(@RequestBody Object payload,
+        @RequirePermission(module = "teachers", action = "c")
+        @PostMapping("/create")
+        public ResponseEntity<?> createTeacher(@RequestBody Object payload,
 											@RequestHeader("Authorization") String authHeader,
 											@RequestParam(defaultValue = "es") String lang) {
 		try {

--- a/src/main/java/com/monarchsolutions/sms/controller/UserController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/UserController.java
@@ -2,6 +2,7 @@ package com.monarchsolutions.sms.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.common.PageResult;
 import com.monarchsolutions.sms.dto.user.CreateUserRequest;
 import com.monarchsolutions.sms.dto.user.UpdatePasswordRequest;
@@ -18,7 +19,6 @@ import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -41,7 +41,7 @@ public class UserController {
 	private ObjectMapper objectMapper;
 
 	// Endpoint to create a new user or multiple users.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
+        @RequirePermission(module = "users", action = "c")
         @PostMapping("/create")
         public ResponseEntity<?> createUser(@RequestBody Object payload,
                                                                                @RequestHeader("Authorization") String authHeader,
@@ -86,8 +86,8 @@ public class UserController {
         }
 
 	// Endpoint to update an existing user.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@PutMapping("/update/{user_id}")
+        @RequirePermission(module = "users", action = "u")
+        @PutMapping("/update/{user_id}")
         public ResponseEntity<?> updateUser(@RequestBody UpdateUserRequest request,
                                                                                @RequestHeader("Authorization") String authHeader,
                                                                                @RequestParam(defaultValue = "es") String lang,
@@ -117,8 +117,8 @@ public class UserController {
         }
 
 	// Endpoint to toggle or change the user's status.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@PostMapping("/update/{userId}/status")
+        @RequirePermission(module = "users", action = "u")
+        @PostMapping("/update/{userId}/status")
         public ResponseEntity<?> changeUserStatus(@PathVariable("userId") Integer userId,
                                                                                @RequestParam(defaultValue = "es") String lang,
                                                                                @RequestHeader("Authorization") String authHeader) throws Exception {
@@ -134,9 +134,9 @@ public class UserController {
         }
 
 	// Endpoint for retrieving the list of users.
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@GetMapping("")
-	public ResponseEntity<?> getUsersList(
+        @RequirePermission(module = "users", action = "r")
+        @GetMapping("")
+        public ResponseEntity<?> getUsersList(
 		@RequestHeader("Authorization") String authHeader,
 		@RequestParam(required = false) Long user_id,
 		@RequestParam(required = false) Long school_id,
@@ -173,8 +173,8 @@ public class UserController {
         }
 
 	// Endpoint for retrieving the user details
-	@PreAuthorize("isAuthenticated()")
-	@GetMapping("/self-details")
+        @RequirePermission(module = "users", action = "r")
+        @GetMapping("/self-details")
         public ResponseEntity<?> getUserSelfDetails(
                 @RequestHeader("Authorization") String authHeader,
                 @RequestParam(defaultValue = "es") String lang
@@ -187,8 +187,8 @@ public class UserController {
         }
 
 	// Endpoint for retrieving the user details
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN')")
-	@GetMapping("/details/{userId:[0-9]+}")
+        @RequirePermission(module = "users", action = "r")
+        @GetMapping("/details/{userId:[0-9]+}")
         public ResponseEntity<?> getUser(
                 @RequestHeader("Authorization") String authHeader,
                 @PathVariable("userId") Long userId,
@@ -220,7 +220,7 @@ public class UserController {
   //   return ResponseEntity.ok(balances);
   // }
 	
-	@PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE')")
+        @RequirePermission(module = "users", action = "r")
   @GetMapping("/balances")
   public ResponseEntity<List<UsersBalanceDTO>> getUsersBalance(
       @RequestHeader("Authorization") String authHeader,
@@ -235,7 +235,7 @@ public class UserController {
     return ResponseEntity.ok(balances);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','SCHOOL_ADMIN','FINANCE')")
+  @RequirePermission(module = "users", action = "r")
   @GetMapping("/globalsearch")
   public ResponseEntity<List<UsersBalanceDTO>> globlaSearch(
       @RequestHeader("Authorization") String authHeader,
@@ -250,8 +250,8 @@ public class UserController {
     return ResponseEntity.ok(balances);
   }
 
-	@PreAuthorize("isAuthenticated()")
-	@PutMapping("/password")
+        @RequirePermission(module = "users", action = "u")
+        @PutMapping("/password")
         public ResponseEntity<Map<String,Object>> updatePassword(
                 @RequestHeader("Authorization") String authHeader,
                 @RequestBody UpdatePasswordRequest req,


### PR DESCRIPTION
## Summary
- replace @PreAuthorize annotations in finance reports, user, school, student, teacher, and role controllers with RequirePermission-based checks
- add a read permission requirement to the scholar level listing endpoint

## Testing
- mvn -DskipTests package *(fails: dependency download blocked by 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928f4481ef88330a2fe8edbbfdb8230)