### PR TITLE
Add permissions roles endpoint with filtering

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
@@ -1,0 +1,37 @@
+package com.monarchsolutions.sms.controller;
+
+import com.monarchsolutions.sms.annotation.RequirePermission;
+import com.monarchsolutions.sms.entity.Role;
+import com.monarchsolutions.sms.service.RoleService;
+import com.monarchsolutions.sms.util.JwtUtil;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/permissions")
+public class PermissionsController {
+
+    @Autowired
+    private RoleService roleService;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @RequirePermission(module = "permissions", action = "r")
+    @GetMapping("/roles")
+    public ResponseEntity<List<Role>> getRolesForPermissions(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestParam(value = "search", required = false) String search,
+            @RequestParam(value = "onlyActive", defaultValue = "false") boolean onlyActive) {
+        String token = authHeader.substring(7);
+        Long tokenUserId = jwtUtil.extractUserId(token);
+        List<Role> roles = roleService.getRolesForUser(tokenUserId, search, onlyActive);
+        return ResponseEntity.ok(roles);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/entity/Role.java
+++ b/src/main/java/com/monarchsolutions/sms/entity/Role.java
@@ -16,11 +16,29 @@ public class Role {
     @Column(name = "role_id")
     private Long roleId;
 
-    @Column(nullable = false, length = 100)
-    private String name;
+    @Column(name = "role_name", nullable = false, length = 255)
+    private String roleName;
 
-    @Column(length = 255)
-    private String description;
+    @Column(name = "name_en", nullable = false, length = 255)
+    private String nameEn;
+
+    @Column(name = "name_es", nullable = false, length = 255)
+    private String nameEs;
+
+    @Column(name = "description_en", length = 255)
+    private String descriptionEn;
+
+    @Column(name = "description_es", length = 255)
+    private String descriptionEs;
+
+    @Column(name = "enabled")
+    private Boolean enabled;
+
+    @Column(name = "school_id")
+    private Long schoolId;
+
+    @Column(name = "role_level")
+    private Integer roleLevel;
 
     public Long getRoleId() {
         return roleId;
@@ -30,19 +48,67 @@ public class Role {
         this.roleId = roleId;
     }
 
-    public String getName() {
-        return name;
+    public String getRoleName() {
+        return roleName;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setRoleName(String roleName) {
+        this.roleName = roleName;
     }
 
-    public String getDescription() {
-        return description;
+    public String getNameEn() {
+        return nameEn;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public void setNameEn(String nameEn) {
+        this.nameEn = nameEn;
+    }
+
+    public String getNameEs() {
+        return nameEs;
+    }
+
+    public void setNameEs(String nameEs) {
+        this.nameEs = nameEs;
+    }
+
+    public String getDescriptionEn() {
+        return descriptionEn;
+    }
+
+    public void setDescriptionEn(String descriptionEn) {
+        this.descriptionEn = descriptionEn;
+    }
+
+    public String getDescriptionEs() {
+        return descriptionEs;
+    }
+
+    public void setDescriptionEs(String descriptionEs) {
+        this.descriptionEs = descriptionEs;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Long getSchoolId() {
+        return schoolId;
+    }
+
+    public void setSchoolId(Long schoolId) {
+        this.schoolId = schoolId;
+    }
+
+    public Integer getRoleLevel() {
+        return roleLevel;
+    }
+
+    public void setRoleLevel(Integer roleLevel) {
+        this.roleLevel = roleLevel;
     }
 }

--- a/src/main/java/com/monarchsolutions/sms/repository/RoleEntityRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/RoleEntityRepository.java
@@ -1,9 +1,36 @@
 package com.monarchsolutions.sms.repository;
 
 import com.monarchsolutions.sms.entity.Role;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoleEntityRepository extends JpaRepository<Role, Long> {
+
+    @Query(value = """
+            SELECT *
+            FROM roles r
+            WHERE r.school_id IN (
+                SELECT u.school_id FROM users u WHERE u.user_id = :tokenUserId LIMIT 1
+                UNION
+                SELECT s.related_school_id
+                FROM users u
+                JOIN schools s ON u.school_id = s.school_id
+                WHERE u.user_id = :tokenUserId
+                LIMIT 1
+            )
+              AND r.school_id IS NOT NULL
+              AND (:searchTerm IS NULL OR r.role_name LIKE CONCAT('%', :searchTerm, '%'))
+              AND (:onlyActive = FALSE OR r.enabled = TRUE)
+            ORDER BY r.enabled DESC, r.role_level ASC, r.role_id ASC
+            """, nativeQuery = true)
+    List<Role> findRolesForUserSchools(
+            @Param("tokenUserId") Long tokenUserId,
+            @Param("searchTerm") String searchTerm,
+            @Param("onlyActive") boolean onlyActive
+    );
 }

--- a/src/main/java/com/monarchsolutions/sms/service/RoleService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/RoleService.java
@@ -1,6 +1,8 @@
 package com.monarchsolutions.sms.service;
 
 import com.monarchsolutions.sms.dto.roles.RolesListResponse;
+import com.monarchsolutions.sms.entity.Role;
+import com.monarchsolutions.sms.repository.RoleEntityRepository;
 import com.monarchsolutions.sms.repository.RoleRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +16,15 @@ public class RoleService {
     @Autowired
     private RoleRepository roleRepository;
 
+    @Autowired
+    private RoleEntityRepository roleEntityRepository;
+
     public List<RolesListResponse> getRoles(String lang, int role_level, int status_filter){
         return roleRepository.getRoles(lang, role_level, status_filter);
+    }
+
+    public List<Role> getRolesForUser(Long tokenUserId, String searchTerm, boolean onlyActive) {
+        String sanitizedSearch = (searchTerm == null || searchTerm.isBlank()) ? null : searchTerm;
+        return roleEntityRepository.findRolesForUserSchools(tokenUserId, sanitizedSearch, onlyActive);
     }
 }


### PR DESCRIPTION
## Summary
- expand the Role entity to map all role table columns used by permissions
- add repository query and service method to fetch roles visible to the token user with search and active filters
- introduce /api/permissions/roles endpoint protected by permissions read access to list roles with active-first ordering

## Testing
- sh ./mvnw test *(fails: unable to download Maven wrapper binaries in the environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692918d2d3d48330be7ed3e85abdc780)