### PR TITLE
Add endpoint for accessible module catalog

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/ModuleController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ModuleController.java
@@ -1,0 +1,47 @@
+package com.monarchsolutions.sms.controller;
+
+import com.monarchsolutions.sms.dto.catalogs.ModuleAccessResponse;
+import com.monarchsolutions.sms.service.ModuleService;
+import com.monarchsolutions.sms.util.JwtUtil;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/modules")
+public class ModuleController {
+
+    private final ModuleService moduleService;
+    private final JwtUtil jwtUtil;
+
+    public ModuleController(ModuleService moduleService, JwtUtil jwtUtil) {
+        this.moduleService = moduleService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @GetMapping("/access-control")
+    public ResponseEntity<List<ModuleAccessResponse>> getAccessibleModules(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestParam(defaultValue = "es") String lang,
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "true") boolean onlyActive,
+            @RequestParam(name = "key", required = false) String moduleKey
+    ) {
+        String token = authHeader.replaceFirst("^Bearer\\s+", "");
+        Long tokenUserId = jwtUtil.extractUserId(token);
+
+        List<ModuleAccessResponse> modules = moduleService.getAccessibleModules(
+                tokenUserId,
+                search,
+                onlyActive,
+                lang,
+                moduleKey
+        );
+
+        return ResponseEntity.ok(modules);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/dto/catalogs/ModuleAccessResponse.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/catalogs/ModuleAccessResponse.java
@@ -1,0 +1,58 @@
+package com.monarchsolutions.sms.dto.catalogs;
+
+public class ModuleAccessResponse {
+    private Long moduleId;
+    private String moduleName;
+    private String moduleKey;
+    private Long moduleAccessControlId;
+    private Long schoolId;
+    private Boolean enabled;
+
+    public Long getModuleId() {
+        return moduleId;
+    }
+
+    public void setModuleId(Long moduleId) {
+        this.moduleId = moduleId;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public String getModuleKey() {
+        return moduleKey;
+    }
+
+    public void setModuleKey(String moduleKey) {
+        this.moduleKey = moduleKey;
+    }
+
+    public Long getModuleAccessControlId() {
+        return moduleAccessControlId;
+    }
+
+    public void setModuleAccessControlId(Long moduleAccessControlId) {
+        this.moduleAccessControlId = moduleAccessControlId;
+    }
+
+    public Long getSchoolId() {
+        return schoolId;
+    }
+
+    public void setSchoolId(Long schoolId) {
+        this.schoolId = schoolId;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/ModuleAccessProjection.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/ModuleAccessProjection.java
@@ -1,0 +1,10 @@
+package com.monarchsolutions.sms.repository;
+
+public interface ModuleAccessProjection {
+    Long getModuleId();
+    String getModuleName();
+    String getModuleKey();
+    Long getModuleAccessControlId();
+    Long getSchoolId();
+    Boolean getEnabled();
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/ModuleRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/ModuleRepository.java
@@ -1,11 +1,56 @@
 package com.monarchsolutions.sms.repository;
 
 import com.monarchsolutions.sms.entity.Module;
+import com.monarchsolutions.sms.repository.ModuleAccessProjection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ModuleRepository extends JpaRepository<Module, Long> {
     Optional<Module> findByKey(String key);
+
+    @Query(value = """
+            SELECT
+              m.module_id AS moduleId,
+              CASE WHEN :lang='en' THEN m.name_en ELSE m.name_es END AS moduleName,
+              m.key AS moduleKey,
+              mac.module_access_control_id AS moduleAccessControlId,
+              mac.school_id AS schoolId,
+              mac.enabled AS enabled
+            FROM modules m
+            JOIN module_access_control mac ON m.module_id = mac.module_id
+            WHERE mac.school_id IN (
+                SELECT school_id
+                FROM (
+                    (SELECT u.school_id AS school_id
+                    FROM users u
+                    WHERE u.user_id = :tokenUserId
+                    LIMIT 1)
+
+                    UNION ALL
+
+                    (SELECT s.related_school_id AS school_id
+                    FROM users u
+                    JOIN schools s ON u.school_id = s.school_id
+                    WHERE u.user_id = :tokenUserId
+                    LIMIT 1)
+                ) AS user_schools
+                WHERE school_id IS NOT NULL
+            )
+              AND (:searchTerm IS NULL OR (CASE WHEN :lang='en' THEN m.name_en ELSE m.name_es END) LIKE CONCAT('%', :searchTerm, '%'))
+              AND (:moduleKey IS NULL OR m.key = :moduleKey)
+              AND (:onlyActive = FALSE OR mac.enabled = TRUE)
+            ORDER BY mac.enabled DESC, m.module_id ASC
+            """, nativeQuery = true)
+    List<ModuleAccessProjection> findModulesForUserSchools(
+            @Param("tokenUserId") Long tokenUserId,
+            @Param("searchTerm") String searchTerm,
+            @Param("onlyActive") boolean onlyActive,
+            @Param("lang") String lang,
+            @Param("moduleKey") String moduleKey
+    );
 }

--- a/src/main/java/com/monarchsolutions/sms/service/ModuleService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/ModuleService.java
@@ -1,0 +1,49 @@
+package com.monarchsolutions.sms.service;
+
+import com.monarchsolutions.sms.dto.catalogs.ModuleAccessResponse;
+import com.monarchsolutions.sms.repository.ModuleAccessProjection;
+import com.monarchsolutions.sms.repository.ModuleRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ModuleService {
+
+    private final ModuleRepository moduleRepository;
+
+    public ModuleService(ModuleRepository moduleRepository) {
+        this.moduleRepository = moduleRepository;
+    }
+
+    public List<ModuleAccessResponse> getAccessibleModules(
+            Long tokenUserId,
+            String searchTerm,
+            boolean onlyActive,
+            String lang,
+            String moduleKey
+    ) {
+        String sanitizedSearch = (searchTerm == null || searchTerm.isBlank()) ? null : searchTerm;
+        String sanitizedModuleKey = (moduleKey == null || moduleKey.isBlank()) ? null : moduleKey;
+
+        List<ModuleAccessProjection> projections = moduleRepository.findModulesForUserSchools(
+                tokenUserId,
+                sanitizedSearch,
+                onlyActive,
+                lang,
+                sanitizedModuleKey
+        );
+
+        return projections.stream()
+                .map(projection -> {
+                    ModuleAccessResponse response = new ModuleAccessResponse();
+                    response.setModuleId(projection.getModuleId());
+                    response.setModuleName(projection.getModuleName());
+                    response.setModuleKey(projection.getModuleKey());
+                    response.setModuleAccessControlId(projection.getModuleAccessControlId());
+                    response.setSchoolId(projection.getSchoolId());
+                    response.setEnabled(projection.getEnabled());
+                    return response;
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
## Summary
- add repository query and projection to retrieve module access records filtered by user school context
- introduce module access DTO/service/controller endpoint with language, status, search, and key filters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292e9b86ec8330a32a85b9aa493fae)