### PR TITLE
Allow authenticated access to permission-guarded controllers

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -1,6 +1,5 @@
 package com.monarchsolutions.sms.controller;
 
-import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.catalogs.PaymentConceptsDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentStatusesDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentThroughDto;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/catalog")
-@RequirePermission(module = "catalogs", action = "r")
 public class CatalogController {
   @Autowired
   private CatalogsService CatalogsService;

--- a/src/main/java/com/monarchsolutions/sms/controller/FilesController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/FilesController.java
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.SchoolService;
 import com.monarchsolutions.sms.util.JwtUtil;
 
@@ -47,7 +45,6 @@ public class FilesController {
   @Autowired
   private JwtUtil jwtUtil;
 
-  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/protectedfiles/{filename:.+}")
   public ResponseEntity<Resource> serveProtectedFile(
       @PathVariable String filename,
@@ -127,7 +124,6 @@ public class FilesController {
   //   }
   // }
 
-  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/school-logo/{school_id}")
   public ResponseEntity<Resource> serveSchoolLogoFile(
       @RequestHeader("Authorization") String authHeader,
@@ -176,7 +172,6 @@ public class FilesController {
     }
   }
 
-  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/coffee-menu-image/{filename:.+}")
   public ResponseEntity<Resource> serveCoffeeMenuImage(
       @PathVariable String filename,
@@ -215,7 +210,6 @@ public class FilesController {
     }
   }
 
-  @RequirePermission(module = "files", action = "r")
   @GetMapping("/api/bulkfile/{filename:.+}")
   public ResponseEntity<Resource> serveBulkFiles(
       @PathVariable String filename,

--- a/src/main/java/com/monarchsolutions/sms/controller/LogsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/LogsController.java
@@ -10,7 +10,6 @@ import com.monarchsolutions.sms.util.JwtUtil;
 import com.monarchsolutions.sms.dto.userLogs.UserLogsListDto;
 import com.monarchsolutions.sms.dto.userLogs.paymentRequest.PaymentRequestLogGroupDto;
 import com.monarchsolutions.sms.dto.userLogs.payments.PaymentLogGroupDto;
-import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.service.LogsService;
 
 @RestController
@@ -24,7 +23,6 @@ public class LogsController {
     private JwtUtil jwtUtil;
     
     // Endpoint for retrieving the list of usersLogs.
-    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/list")
     public ResponseEntity<?> getUsersActivityLog(
                                         // @RequestHeader("Authorization") String authHeader,
@@ -41,7 +39,6 @@ public class LogsController {
     }
 
     // Endpoint for retrieving the list of paymentRequestLogs.
-    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/payment-requests/{paymentRequestId}")
     public ResponseEntity<List<PaymentRequestLogGroupDto>> getPaymentRequestLogs(
             @RequestHeader("Authorization") String authHeader,
@@ -63,7 +60,6 @@ public class LogsController {
     }
     
     // Endpoint for retrieving the list of paymentLogs.
-    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/payment/{paymentId}")
     public ResponseEntity<List<PaymentLogGroupDto>> getPaymentLogs(
             @RequestHeader("Authorization") String authHeader,
@@ -85,7 +81,6 @@ public class LogsController {
     }
 
     // Endpoint to retrieve scheduled job logs from stored procedure getScheduledJobLogs
-    @RequirePermission(module = "logs", action = "r")
     @GetMapping("/scheduled-jobs")
     public ResponseEntity<List<Map<String, Object>>> getScheduledJobLogs(
             @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
@@ -1,6 +1,5 @@
 package com.monarchsolutions.sms.controller;
 
-import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.permission.ModulePermissionResponse;
 import com.monarchsolutions.sms.entity.Role;
 import com.monarchsolutions.sms.service.PermissionService;
@@ -28,7 +27,6 @@ public class PermissionsController {
     @Autowired
     private JwtUtil jwtUtil;
 
-    @RequirePermission(module = "catalogs", action = "r")
     @GetMapping("/roles")
     public ResponseEntity<List<Role>> getRolesForPermissions(
             @RequestHeader("Authorization") String authHeader,

--- a/src/main/java/com/monarchsolutions/sms/controller/RoleController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/RoleController.java
@@ -7,8 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import com.monarchsolutions.sms.util.JwtUtil;
-import com.monarchsolutions.sms.annotation.RequirePermission;
-
 import com.monarchsolutions.sms.dto.roles.RolesListResponse;
 import com.monarchsolutions.sms.service.RoleService;
 
@@ -23,7 +21,6 @@ public class RoleController {
     private JwtUtil jwtUtil;
 
     // Endpoint for retrieving the list of roles.
-    @RequirePermission(module = "roles", action = "r")
     @GetMapping("")
     public ResponseEntity<?> getRoles(@RequestParam(defaultValue = "es") String lang,
                                       @RequestParam(defaultValue = "-1") int status_filter,

--- a/src/main/java/com/monarchsolutions/sms/controller/ScholarLevelController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ScholarLevelController.java
@@ -1,6 +1,5 @@
 package com.monarchsolutions.sms.controller;
 
-import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.common.ScholarLevelsDTO;
 import com.monarchsolutions.sms.service.ScholarLevelService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +15,6 @@ public class ScholarLevelController {
     @Autowired
     private ScholarLevelService scholarLevelService;
 
-    @RequirePermission(module = "scholar_levels", action = "r")
     @GetMapping("/list")
     public ResponseEntity<List<ScholarLevelsDTO>> getScholarLevels(@RequestParam(defaultValue = "es") String lang) {
         List<ScholarLevelsDTO> responses = scholarLevelService.getScholarLevels(lang);


### PR DESCRIPTION
## Summary
- remove role-based permission annotations from catalog, files, logs, permissions, roles, and scholar-level controllers to allow access for any authenticated user
- retain existing endpoint behavior while relying on global authentication instead of per-module permission checks

## Testing
- `./mvnw -q -DskipTests compile` *(fails: unable to fetch Maven distribution from repo.maven.apache.org)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2eee711c8330aa7d17ee6a4e3032)