### PR TITLE
Add paginated schools endpoint using new getSchools SP

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/SchoolController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/SchoolController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import com.monarchsolutions.sms.dto.school.CreateSchoolRequest;
 import com.monarchsolutions.sms.dto.school.UpdateSchoolRequest;
 import com.monarchsolutions.sms.dto.school.SchoolsList;
+import com.monarchsolutions.sms.dto.school.GetSchoolsResponse;
 import com.monarchsolutions.sms.service.SchoolService;
 import com.monarchsolutions.sms.util.JwtUtil;
 
@@ -25,7 +26,42 @@ public class SchoolController {
 	private SchoolService schoolService;
 
 	@Autowired
-	private JwtUtil jwtUtil;
+        private JwtUtil jwtUtil;
+
+        @RequirePermission(module = "schools", action = "r")
+        @GetMapping("/paged")
+        public ResponseEntity<?> getSchools(
+                        @RequestHeader("Authorization") String authHeader,
+                        @RequestParam(required = false) Long  school_id,
+                        @RequestParam(defaultValue = "es")  String lang,
+                        @RequestParam(defaultValue = "-1") Integer status_filter,
+                        @RequestParam(defaultValue = "0")   Integer offset,
+                        @RequestParam(defaultValue = "10")  Integer limit,
+                        @RequestParam(defaultValue = "0")   boolean export_all,
+                        @RequestParam(required = false)      String order_by,
+                        @RequestParam(required = false)      String order_dir
+        ) {
+                try {
+                        String token = authHeader.substring(7);
+                        Long   userId = jwtUtil.extractUserId(token);
+
+                        GetSchoolsResponse response = schoolService.getSchools(
+                                        userId,
+                                        school_id,
+                                        lang,
+                                        status_filter,
+                                        offset,
+                                        limit,
+                                        export_all,
+                                        order_by,
+                                        order_dir
+                        );
+
+                        return ResponseEntity.ok(response);
+                } catch (Exception e) {
+                        return ResponseEntity.badRequest().body(e.getMessage());
+                }
+        }
 
 	// Endpoint to create a new school
         @RequirePermission(module = "schools", action = "c")

--- a/src/main/java/com/monarchsolutions/sms/dto/school/GetSchoolsResponse.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/school/GetSchoolsResponse.java
@@ -1,0 +1,24 @@
+package com.monarchsolutions.sms.dto.school;
+
+import java.util.List;
+
+public class GetSchoolsResponse {
+    private List<SchoolSummary> schools;
+    private Integer total_count;
+
+    public List<SchoolSummary> getSchools() {
+        return schools;
+    }
+
+    public void setSchools(List<SchoolSummary> schools) {
+        this.schools = schools;
+    }
+
+    public Integer getTotal_count() {
+        return total_count;
+    }
+
+    public void setTotal_count(Integer total_count) {
+        this.total_count = total_count;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/dto/school/SchoolSummary.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/school/SchoolSummary.java
@@ -1,0 +1,85 @@
+package com.monarchsolutions.sms.dto.school;
+
+public class SchoolSummary {
+    private Long school_id;
+    private Long related_school_id;
+    private String description;
+    private String commercial_name;
+    private Boolean enabled;
+    private String school_status;
+    private String image;
+    private String plan_name;
+    private boolean is_parent_school;
+
+    public Long getSchool_id() {
+        return school_id;
+    }
+
+    public void setSchool_id(Long school_id) {
+        this.school_id = school_id;
+    }
+
+    public Long getRelated_school_id() {
+        return related_school_id;
+    }
+
+    public void setRelated_school_id(Long related_school_id) {
+        this.related_school_id = related_school_id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCommercial_name() {
+        return commercial_name;
+    }
+
+    public void setCommercial_name(String commercial_name) {
+        this.commercial_name = commercial_name;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getSchool_status() {
+        return school_status;
+    }
+
+    public void setSchool_status(String school_status) {
+        this.school_status = school_status;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getPlan_name() {
+        return plan_name;
+    }
+
+    public void setPlan_name(String plan_name) {
+        this.plan_name = plan_name;
+    }
+
+    public boolean isIs_parent_school() {
+        return is_parent_school;
+    }
+
+    public void setIs_parent_school(boolean is_parent_school) {
+        this.is_parent_school = is_parent_school;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/SchoolRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/SchoolRepository.java
@@ -4,18 +4,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.monarchsolutions.sms.dto.school.SchoolsList;
 import com.monarchsolutions.sms.dto.school.CreateSchoolRequest;
 import com.monarchsolutions.sms.dto.school.UpdateSchoolRequest;
+import com.monarchsolutions.sms.dto.school.GetSchoolsResponse;
+import com.monarchsolutions.sms.dto.school.SchoolSummary;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.ParameterMode;
 import jakarta.persistence.StoredProcedureQuery;
 
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.hibernate.Session;
 
 @Repository
 public class SchoolRepository {
@@ -23,7 +30,70 @@ public class SchoolRepository {
 	private EntityManager entityManager;
 	
 	@Autowired
-	private ObjectMapper objectMapper;
+        private ObjectMapper objectMapper;
+
+        public GetSchoolsResponse getSchools(
+                        Long p_token_user_id,
+                        Long p_school_id,
+                        String lang,
+                        Integer p_status_filter,
+                        Integer p_offset,
+                        Integer p_limit,
+                        boolean p_export_all,
+                        String p_order_by,
+                        String p_order_dir
+        ) {
+                var response = new GetSchoolsResponse();
+                var schools  = new ArrayList<SchoolSummary>();
+                var total    = new AtomicInteger(0);
+
+                entityManager.unwrap(Session.class).doWork(connection -> {
+                        try (CallableStatement stmt = connection.prepareCall("{CALL getSchools(?,?,?,?,?,?,?,?,?)}")) {
+                                stmt.setObject(1, p_token_user_id, Types.INTEGER);
+                                stmt.setObject(2, p_school_id, Types.INTEGER);
+                                stmt.setString(3, lang);
+                                stmt.setObject(4, p_status_filter, Types.INTEGER);
+                                stmt.setObject(5, p_offset, Types.INTEGER);
+                                stmt.setObject(6, p_limit, Types.INTEGER);
+                                stmt.setBoolean(7, p_export_all);
+                                stmt.setString(8, p_order_by);
+                                stmt.setString(9, p_order_dir);
+
+                                boolean hasResults = stmt.execute();
+
+                                if (hasResults) {
+                                        try (ResultSet rs = stmt.getResultSet()) {
+                                                while (rs.next()) {
+                                                        var school = new SchoolSummary();
+                                                        school.setSchool_id(rs.getObject("school_id", Long.class));
+                                                        school.setRelated_school_id(rs.getObject("related_school_id", Long.class));
+                                                        school.setDescription(rs.getString("description"));
+                                                        school.setCommercial_name(rs.getString("commercial_name"));
+                                                        var enabled = rs.getObject("enabled");
+                                                        school.setEnabled(enabled != null ? rs.getBoolean("enabled") : null);
+                                                        school.setSchool_status(rs.getString("school_status"));
+                                                        school.setImage(rs.getString("image"));
+                                                        school.setPlan_name(rs.getString("plan_name"));
+                                                        school.setIs_parent_school(rs.getInt("is_parent_school") == 1);
+                                                        schools.add(school);
+                                                }
+                                        }
+                                }
+
+                                if (stmt.getMoreResults()) {
+                                        try (ResultSet countRs = stmt.getResultSet()) {
+                                                if (countRs.next()) {
+                                                        total.set(countRs.getInt("total_count"));
+                                                }
+                                        }
+                                }
+                        }
+                });
+
+                response.setSchools(schools);
+                response.setTotal_count(total.get());
+                return response;
+        }
 
 	// Get Schools List
 	public List<SchoolsList> getSchoolsList(Long token_user_id, Long school_id, String lang, int statusFilter) {

--- a/src/main/java/com/monarchsolutions/sms/service/SchoolService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/SchoolService.java
@@ -2,6 +2,7 @@ package com.monarchsolutions.sms.service;
 
 import com.monarchsolutions.sms.dto.school.SchoolsList;
 import com.monarchsolutions.sms.dto.school.UpdateSchoolRequest;
+import com.monarchsolutions.sms.dto.school.GetSchoolsResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.monarchsolutions.sms.dto.school.CreateSchoolRequest;
@@ -34,12 +35,36 @@ public class SchoolService {
 	@Autowired
 	private SchoolRepository schoolRepository;
 
-	@Autowired
+        @Autowired
   private ObjectMapper objectMapper;
 
-	public List<SchoolsList> getSchoolsList(Long token_user_id, Long school_id, String lang, int statusFilter) {
-		return schoolRepository.getSchoolsList(token_user_id, school_id, lang, statusFilter);
-	}
+        public GetSchoolsResponse getSchools(
+                        Long   p_token_user_id,
+                        Long   p_school_id,
+                        String lang,
+                        Integer p_status_filter,
+                        Integer p_offset,
+                        Integer p_limit,
+                        boolean p_export_all,
+                        String p_order_by,
+                        String p_order_dir
+        ) {
+                return schoolRepository.getSchools(
+                        p_token_user_id,
+                        p_school_id,
+                        lang,
+                        p_status_filter,
+                        p_offset,
+                        p_limit,
+                        p_export_all,
+                        p_order_by,
+                        p_order_dir
+                );
+        }
+
+        public List<SchoolsList> getSchoolsList(Long token_user_id, Long school_id, String lang, int statusFilter) {
+                return schoolRepository.getSchoolsList(token_user_id, school_id, lang, statusFilter);
+        }
 
 	public List<SchoolsList> getRelatedSchoolList(Long user_school_id, Long school_id, String lang) {
 		return schoolRepository.getRelatedSchoolList(user_school_id, school_id, lang);


### PR DESCRIPTION
## Summary
- add a paginated schools endpoint that proxies query params to the getSchools stored procedure
- map the stored procedure results into DTOs with school summaries and total count metadata
- wire service and repository layers to execute the procedure with sorting, status, and export options

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven distribution due to network fetch error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b70e8572c833085ca7743f9031726)