### PR TITLE
Update permission query to detect admin access

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
@@ -55,20 +55,12 @@ public class PermissionsController {
     ) {
         String token = authHeader.replaceFirst("^Bearer\\s+", "");
         Long tokenUserId = jwtUtil.extractUserId(token);
-        Long roleId = jwtUtil.extractRoleId(token);
-        Long tokenSchoolId = jwtUtil.extractSchoolId(token);
-        String role = jwtUtil.extractUserRole(token);
-        Boolean isAdmin = "ADMIN".equalsIgnoreCase(role) ? true : false;
-
 
         List<ModulePermissionResponse> modulePermissions = permissionService.getModulePermissionsForUser(
                 tokenUserId,
-                roleId,
-                tokenSchoolId,
                 moduleKey,
                 lang,
-                onlyActive,
-                isAdmin
+                onlyActive
         );
 
         return ResponseEntity.ok(modulePermissions);

--- a/src/main/java/com/monarchsolutions/sms/repository/PermissionRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PermissionRepository.java
@@ -13,57 +13,94 @@ public interface PermissionRepository extends JpaRepository<Permission, Long> {
     Optional<Permission> findByRole_RoleIdAndModule_ModuleId(Long roleId, Long moduleId);
 
     @Query(value = """
-            SELECT
-              m.module_id AS moduleId,
-              CASE WHEN :lang='en' THEN m.name_en ELSE m.name_es END AS moduleName,
-              m.key AS moduleKey,
-              mac.module_access_control_id AS moduleAccessControlId,
-              mac.school_id AS schoolId,
-              mac.enabled AS enabled,
-              r.role_id AS roleId,
-              -- r.role_name AS roleName,
-              CASE WHEN :lang='en' THEN r.name_en ELSE r.name_es END AS roleNameDisplay,
-              p.c AS createAllowed,
-              p.r AS readAllowed,
-              p.u AS updateAllowed,
-              p.d AS deleteAllowed
-            FROM permissions p
-            JOIN modules m ON p.module_id = m.module_id
-            JOIN roles r ON r.role_id = p.role_id
-            JOIN module_access_control mac ON m.module_id = mac.module_id
-            WHERE (
-              :isAdmin = TRUE AND mac.school_id IS NULL
-              OR mac.school_id IN (
+            (
+                /* ===============================
+                   ADMIN: role_id = 0 o 1
+                   Acceso total sin permissions
+                =============================== */
+                SELECT
+                    m.module_id            AS moduleId,
+                    CASE WHEN :lang='en' THEN m.name_en ELSE m.name_es END AS moduleName,
+                    m.key                  AS moduleKey,
+                    mac.module_access_control_id AS moduleAccessControlId,
+                    mac.school_id           AS schoolId,
+                    mac.enabled             AS enabled,
+                    u.role_id               AS roleId,
+                    CASE WHEN :lang='en' THEN 'Administrator' ELSE 'Administrador' END AS roleNameDisplay,
+                    1 AS createAllowed,
+                    1 AS readAllowed,
+                    1 AS updateAllowed,
+                    1 AS deleteAllowed
+                FROM users u
+                JOIN modules m
+                  ON m.key = :moduleKey
+                LEFT JOIN module_access_control mac
+                  ON mac.module_id = m.module_id
+                WHERE u.user_id = :tokenUserId
+                  AND u.role_id IN (0,1)
+
+                LIMIT 1
+            )
+
+            UNION ALL
+
+            (
+                /* ===============================
+                   USUARIOS NORMALES
+                   Validación por permissions
+                =============================== */
+                SELECT
+                    m.module_id AS moduleId,
+                    CASE WHEN :lang='en' THEN m.name_en ELSE m.name_es END AS moduleName,
+                    m.key AS moduleKey,
+                    mac.module_access_control_id AS moduleAccessControlId,
+                    mac.school_id AS schoolId,
+                    mac.enabled AS enabled,
+                    r.role_id AS roleId,
+                    CASE WHEN :lang='en' THEN r.name_en ELSE r.name_es END AS roleNameDisplay,
+                    p.c AS createAllowed,
+                    p.r AS readAllowed,
+                    p.u AS updateAllowed,
+                    p.d AS deleteAllowed
+                FROM permissions p
+                JOIN modules m ON p.module_id = m.module_id
+                JOIN roles r ON r.role_id = p.role_id
+                JOIN module_access_control mac ON m.module_id = mac.module_id
+                JOIN users u ON u.role_id = r.role_id
+                WHERE u.user_id = :tokenUserId
+                  AND u.role_id NOT IN (0,1)
+
+                  /* === scope por escuela === */
+                  AND mac.school_id IN (
                       SELECT school_id
                       FROM (
-                          (SELECT u.school_id AS school_id
-                          FROM users u
-                          WHERE u.user_id = :tokenUserId
-                          LIMIT 1)
+                          SELECT u2.school_id AS school_id
+                          FROM users u2
+                          WHERE u2.user_id = :tokenUserId
 
                           UNION ALL
 
-                          (SELECT s.related_school_id AS school_id
-                          FROM users u
-                          JOIN schools s ON u.school_id = s.school_id
-                          WHERE u.user_id = :tokenUserId
-                          LIMIT 1)
-                      ) AS user_schools
+                          SELECT s.related_school_id
+                          FROM users u2
+                          JOIN schools s ON u2.school_id = s.school_id
+                          WHERE u2.user_id = :tokenUserId
+                      ) x
                       WHERE school_id IS NOT NULL
-              )
+                  )
+
+                  AND m.key = :moduleKey
+                  AND (:onlyActive = FALSE OR mac.enabled = TRUE)
+
+                ORDER BY mac.enabled DESC, m.module_id ASC
+                LIMIT 1
             )
-              AND m.key = :moduleKey
-              AND r.role_id = :roleId
-              AND (:onlyActive = FALSE OR mac.enabled = TRUE)
-            ORDER BY mac.enabled DESC, m.module_id ASC LIMIT 1
+
+            LIMIT 1;
             """, nativeQuery = true)
     List<ModulePermissionProjection> findModulePermissionsForRole(
             @Param("tokenUserId") Long tokenUserId,
-            @Param("roleId") Long roleId,
-            @Param("tokenSchoolId") Long tokenSchoolId,
             @Param("moduleKey") String moduleKey,
             @Param("lang") String lang,
-            @Param("onlyActive") boolean onlyActive,
-            @Param("isAdmin") boolean isAdmin
+            @Param("onlyActive") boolean onlyActive
     );
 }

--- a/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
@@ -69,25 +69,19 @@ public class PermissionService {
     @Transactional(readOnly = true)
     public List<ModulePermissionResponse> getModulePermissionsForUser(
             Long tokenUserId,
-            Long roleId,
-            Long tokenSchoolId,
             String moduleKey,
             String lang,
-            boolean onlyActive,
-            boolean isAdmin
+            boolean onlyActive
     ) {
-        if (tokenUserId == null || roleId == null || moduleKey == null || moduleKey.isBlank()) {
+        if (tokenUserId == null || moduleKey == null || moduleKey.isBlank()) {
             return List.of();
         }
 
         List<ModulePermissionProjection> projections = permissionRepository.findModulePermissionsForRole(
                 tokenUserId,
-                roleId,
-                tokenSchoolId,
                 moduleKey,
                 lang,
-                onlyActive,
-                isAdmin
+                onlyActive
         );
 
         return projections.stream()


### PR DESCRIPTION
## Summary
- remove explicit admin flag handling in the permissions controller and service
- update module permission retrieval query to determine admin users via role_id and include new union logic

## Testing
- `mvn -q -DskipTests compile` *(fails: could not resolve Spring Boot parent POM due to HTTP 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693de4f820c483308b0f47191918ddc7)