### PR TITLE
Handle byte values in module permission projection

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/repository/ModulePermissionProjection.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/ModulePermissionProjection.java
@@ -6,15 +6,15 @@ public interface ModulePermissionProjection {
     String getModuleKey();
     Long getModuleAccessControlId();
     Long getSchoolId();
-    Boolean getEnabled();
+    Byte getEnabled();
     Long sortOrder();
 
     Long getRoleId();
     String getRoleName();
     String getRoleNameDisplay();
 
-    Boolean getCreateAllowed();
-    Boolean getReadAllowed();
-    Boolean getUpdateAllowed();
-    Boolean getDeleteAllowed();
+    Byte getCreateAllowed();
+    Byte getReadAllowed();
+    Byte getUpdateAllowed();
+    Byte getDeleteAllowed();
 }

--- a/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
@@ -92,17 +92,21 @@ public class PermissionService {
                     response.setModuleKey(projection.getModuleKey());
                     response.setModuleAccessControlId(projection.getModuleAccessControlId());
                     response.setSchoolId(projection.getSchoolId());
-                    response.setEnabled(projection.getEnabled());
+                    response.setEnabled(byteToBoolean(projection.getEnabled()));
                     response.setRoleId(projection.getRoleId());
                     response.setRoleName(projection.getRoleName());
                     response.setRoleNameDisplay(projection.getRoleNameDisplay());
-                    response.setCreateAllowed(projection.getCreateAllowed());
-                    response.setReadAllowed(projection.getReadAllowed());
-                    response.setUpdateAllowed(projection.getUpdateAllowed());
-                    response.setDeleteAllowed(projection.getDeleteAllowed());
+                    response.setCreateAllowed(byteToBoolean(projection.getCreateAllowed()));
+                    response.setReadAllowed(byteToBoolean(projection.getReadAllowed()));
+                    response.setUpdateAllowed(byteToBoolean(projection.getUpdateAllowed()));
+                    response.setDeleteAllowed(byteToBoolean(projection.getDeleteAllowed()));
                     return response;
                 })
                 .toList();
+    }
+
+    private Boolean byteToBoolean(Byte value) {
+        return value != null && value != 0;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- adjust module permission projection to use byte values returned by native queries
- convert database byte flags to booleans before building the response payload

## Testing
- mvn -q -DskipTests compile *(fails: cannot download parent POM due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693de9bbe68c83309f02d9f5f0145c54)