### PR TITLE
Add update permission stored procedure endpoint

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PermissionsController.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -96,6 +97,20 @@ public class PermissionsController {
         Long tokenUserId = jwtUtil.extractUserId(token);
 
         Map<String, Object> response = permissionService.createPermission(tokenUserId, payload, lang);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<Map<String, Object>> updatePermission(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestParam("permissionId") Long permissionId,
+            @RequestBody Map<String, Object> payload,
+            @RequestParam(defaultValue = "es") String lang
+    ) throws Exception {
+        String token = authHeader.replaceFirst("^Bearer\\s+", "");
+        Long tokenUserId = jwtUtil.extractUserId(token);
+
+        Map<String, Object> response = permissionService.updatePermission(tokenUserId, permissionId, payload, lang);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/monarchsolutions/sms/repository/PermissionProcedureRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/PermissionProcedureRepository.java
@@ -98,4 +98,40 @@ public class PermissionProcedureRepository {
 
         return response;
     }
+
+    public Map<String, Object> updatePermission(Long tokenUserId, Long permissionId, Object payload, String lang)
+            throws Exception {
+        String call = "{CALL updatePermission(?,?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            if (permissionId != null) {
+                stmt.setInt(2, permissionId.intValue());
+            } else {
+                stmt.setNull(2, Types.INTEGER);
+            }
+
+            stmt.setString(3, payloadJson);
+            stmt.setString(4, lang);
+
+            boolean hasResultSet = stmt.execute();
+            if (hasResultSet) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    if (rs.next()) {
+                        String jsonResponse = rs.getString(1);
+                        response = objectMapper.readValue(jsonResponse, Map.class);
+                    }
+                }
+            }
+        }
+
+        return response;
+    }
 }

--- a/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PermissionService.java
@@ -123,4 +123,10 @@ public class PermissionService {
     public Map<String, Object> createPermission(Long tokenUserId, Object payload, String lang) throws Exception {
         return permissionProcedureRepository.createPermission(tokenUserId, payload, lang);
     }
+
+    @Transactional
+    public Map<String, Object> updatePermission(Long tokenUserId, Long permissionId, Object payload, String lang)
+            throws Exception {
+        return permissionProcedureRepository.updatePermission(tokenUserId, permissionId, payload, lang);
+    }
 }


### PR DESCRIPTION
## Summary
- add repository support to call the `updatePermission` stored procedure
- expose service and controller endpoint to update permissions via API

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve parent POM because Spring Boot parent dependency could not be downloaded in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e0b5aa4cc8330a11cf5189e5440a3)