### PR TITLE
Add catalog endpoint to retrieve plan modules

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -4,6 +4,7 @@ import com.monarchsolutions.sms.dto.catalogs.PaymentConceptsDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentStatusesDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentThroughDto;
 import com.monarchsolutions.sms.dto.catalogs.PeriodOfTimeDto;
+import com.monarchsolutions.sms.dto.catalogs.PlanModuleDto;
 import com.monarchsolutions.sms.dto.catalogs.ScholarLevelsDto;
 import com.monarchsolutions.sms.service.CatalogsService;
 import com.monarchsolutions.sms.util.JwtUtil;
@@ -53,5 +54,15 @@ public class CatalogController {
       String token    = authHeader.replaceFirst("^Bearer\\s+", "");
       Long   token_user_id = jwtUtil.extractUserId(token);
       return ResponseEntity.ok(CatalogsService.getPeriodOfTime(lang, token_user_id));
+  }
+
+  @GetMapping("/plan-modules")
+  public ResponseEntity<List<PlanModuleDto>> planModules(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestParam(name = "school_id", required = false) Long schoolId,
+          @RequestParam(defaultValue = "es") String lang) {
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      return ResponseEntity.ok(CatalogsService.getPlanModules(lang, tokenUserId, schoolId));
   }
 }

--- a/src/main/java/com/monarchsolutions/sms/dto/catalogs/PlanModuleDto.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/catalogs/PlanModuleDto.java
@@ -1,0 +1,8 @@
+package com.monarchsolutions.sms.dto.catalogs;
+
+public interface PlanModuleDto {
+    Long getModuleId();
+    String getModuleName();
+    String getModuleKey();
+    String getModuleDescription();
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/catalogs/PlanModulesRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/catalogs/PlanModulesRepository.java
@@ -1,0 +1,73 @@
+package com.monarchsolutions.sms.repository.catalogs;
+
+import com.monarchsolutions.sms.dto.catalogs.PlanModuleDto;
+import com.monarchsolutions.sms.entity.Module;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PlanModulesRepository extends JpaRepository<Module, Long> {
+
+    @Query(value = """
+        SELECT DISTINCT
+            m.module_id AS moduleId,
+            CASE 
+                WHEN :lang = 'en' THEN m.name_en 
+                ELSE m.name_es 
+            END AS moduleName,
+            m.`key` AS moduleKey,
+            CASE 
+                WHEN :lang = 'en' THEN m.description_en 
+                ELSE m.description_es 
+            END AS moduleDescription
+        FROM school_plans sp
+        JOIN plan_modules pm ON sp.plan_id = pm.plan_id
+        JOIN modules m ON pm.module_id = m.module_id
+
+        /* ===========================
+           CONTEXTO DE ESCUELA
+           =========================== */
+        LEFT JOIN schools s_sp ON sp.school_id = s_sp.school_id
+        LEFT JOIN users u     ON u.user_id = :token_user_id
+        LEFT JOIN schools s_u ON u.school_id = s_u.school_id
+
+        WHERE
+        (
+            /* ======================================
+               CASO 1: USUARIO TIENE ESCUELA
+               ====================================== */
+            u.school_id IS NOT NULL
+            AND (
+                sp.school_id = u.school_id
+                OR sp.school_id = s_u.related_school_id
+            )
+        )
+        OR
+        (
+            /* ======================================
+               CASO 2: USUARIO SIN ESCUELA
+               ====================================== */
+            u.school_id IS NULL
+            AND (
+                sp.school_id = :p_school_id
+                OR sp.school_id = (
+                    SELECT related_school_id
+                    FROM schools
+                    WHERE school_id = :p_school_id
+                )
+            )
+        )
+
+        ORDER BY
+            CASE 
+                WHEN :lang = 'en' THEN m.name_en 
+                ELSE m.name_es 
+            END ASC
+        """, nativeQuery = true)
+    List<PlanModuleDto> findPlanModules(
+            @Param("lang") String lang,
+            @Param("token_user_id") Long tokenUserId,
+            @Param("p_school_id") Long schoolId
+    );
+}

--- a/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
@@ -5,12 +5,14 @@ import com.monarchsolutions.sms.dto.catalogs.PaymentStatusesDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentThroughDto;
 import com.monarchsolutions.sms.dto.catalogs.ScholarLevelsDto;
 import com.monarchsolutions.sms.dto.catalogs.PeriodOfTimeDto;
+import com.monarchsolutions.sms.dto.catalogs.PlanModuleDto;
 
 import com.monarchsolutions.sms.repository.catalogs.PaymentConceptsRepository;
 import com.monarchsolutions.sms.repository.catalogs.PaymentStatusesRepository;
 import com.monarchsolutions.sms.repository.catalogs.PaymentThroughRepository;
 import com.monarchsolutions.sms.repository.catalogs.ScholarLevelsRepository;
 import com.monarchsolutions.sms.repository.catalogs.PeriodsOfTimeRepository;
+import com.monarchsolutions.sms.repository.catalogs.PlanModulesRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,8 @@ public class CatalogsService {
   private ScholarLevelsRepository scholarLevelsRepository;
   @Autowired
   private PeriodsOfTimeRepository periodsOfTimeRepository;
+  @Autowired
+  private PlanModulesRepository planModulesRepository;
 
   public List<PaymentConceptsDto> getPaymentConcepts(String lang) {
       return paymentConceptsRepository.findAllByLang(lang);
@@ -49,6 +53,10 @@ public class CatalogsService {
   
   public List<PeriodOfTimeDto> getPeriodOfTime(String lang, Long tokenUserId) {
       return periodsOfTimeRepository.findAllByLang(lang, tokenUserId);
+  }
+
+  public List<PlanModuleDto> getPlanModules(String lang, Long tokenUserId, Long schoolId) {
+      return planModulesRepository.findPlanModules(lang, tokenUserId, schoolId);
   }
   
 }


### PR DESCRIPTION
## Summary
- add DTO and repository to fetch plan modules for a school's plan
- expose catalog endpoint that extracts user from JWT and delegates to service
- wire catalog service to retrieve modules based on language and school context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e1e5e62c48330bace197305a0a0fd)