### PR TITLE
Add endpoint for student counts by scholar level

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/StudentController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/StudentController.java
@@ -166,7 +166,7 @@ public class StudentController {
         }
     }
 	
-        @RequirePermission(module = "students", action = "r")
+    @RequirePermission(module = "students", action = "r")
     @GetMapping("/validate-exist")
     public ResponseEntity<List<ValidateStudentExist>> validateStudentExists(
         @RequestHeader("Authorization") String authHeader,
@@ -180,6 +180,21 @@ public class StudentController {
 
         List<ValidateStudentExist> students = studentService.validateStudentExists(token_user_id, register_id, payment_reference, username);
         return ResponseEntity.ok(students);
+    }
+
+    @RequirePermission(module = "students", action = "r")
+    @GetMapping("/counts/by-scholar-level")
+    public ResponseEntity<?> getStudentsCountByScholarLevel(
+        @RequestHeader("Authorization") String authHeader,
+        @RequestParam(defaultValue = "es") String lang
+    ) {
+        try {
+            String token = authHeader.replaceFirst("^Bearer\\s+", "");
+            Long tokenUserId = jwtUtil.extractUserId(token);
+            return ResponseEntity.ok(studentService.getStudentsCountByScholarLevel(tokenUserId, lang));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 
     

--- a/src/main/java/com/monarchsolutions/sms/dto/student/StudentCountsResponse.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/student/StudentCountsResponse.java
@@ -1,0 +1,30 @@
+package com.monarchsolutions.sms.dto.student;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StudentCountsResponse {
+
+    @JsonProperty("total_students")
+    private Long totalStudents;
+
+    @JsonProperty("by_scholar_level")
+    private List<StudentScholarLevelCount> byScholarLevel;
+
+    public Long getTotalStudents() {
+        return totalStudents;
+    }
+
+    public void setTotalStudents(Long totalStudents) {
+        this.totalStudents = totalStudents;
+    }
+
+    public List<StudentScholarLevelCount> getByScholarLevel() {
+        return byScholarLevel;
+    }
+
+    public void setByScholarLevel(List<StudentScholarLevelCount> byScholarLevel) {
+        this.byScholarLevel = byScholarLevel;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/dto/student/StudentScholarLevelCount.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/student/StudentScholarLevelCount.java
@@ -1,0 +1,39 @@
+package com.monarchsolutions.sms.dto.student;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StudentScholarLevelCount {
+
+    @JsonProperty("scholar_level_id")
+    private Long scholarLevelId;
+
+    @JsonProperty("scholar_level_name")
+    private String scholarLevelName;
+
+    @JsonProperty("student_count")
+    private Long studentCount;
+
+    public Long getScholarLevelId() {
+        return scholarLevelId;
+    }
+
+    public void setScholarLevelId(Long scholarLevelId) {
+        this.scholarLevelId = scholarLevelId;
+    }
+
+    public String getScholarLevelName() {
+        return scholarLevelName;
+    }
+
+    public void setScholarLevelName(String scholarLevelName) {
+        this.scholarLevelName = scholarLevelName;
+    }
+
+    public Long getStudentCount() {
+        return studentCount;
+    }
+
+    public void setStudentCount(Long studentCount) {
+        this.studentCount = studentCount;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/StudentService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/StudentService.java
@@ -10,6 +10,7 @@ import com.monarchsolutions.sms.dto.student.CreateStudentRequest;
 import com.monarchsolutions.sms.dto.student.GetStudent;
 import com.monarchsolutions.sms.dto.student.GetStudentDetails;
 import com.monarchsolutions.sms.dto.student.UpdateStudentRequest;
+import com.monarchsolutions.sms.dto.student.StudentCountsResponse;
 import com.monarchsolutions.sms.dto.student.ValidateStudentExist;
 import com.monarchsolutions.sms.repository.StudentRepository;
 
@@ -89,5 +90,9 @@ public class StudentService {
     public List<ValidateStudentExist> validateStudentExists(Long token_user_id,String register_id,String payment_reference,String username) {
         // If tokenSchoolId is not null, the SP will filter users by school.
         return studentRepository.validateStudentExists(token_user_id, register_id, payment_reference, username);
+    }
+
+    public StudentCountsResponse getStudentsCountByScholarLevel(Long tokenUserId, String lang) throws Exception {
+        return studentRepository.getStudentsCountByScholarLevel(tokenUserId, lang);
     }
 }


### PR DESCRIPTION
## Summary
- add DTOs to model student count totals and per-scholar-level breakdowns
- implement repository method executing the count query and mapping JSON into DTOs
- expose a new `/api/students/counts/by-scholar-level` endpoint to return the counts for the requesting user

## Testing
- `mvn -DskipTests compile` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 due to 403 from repo.maven.apache.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c2f96b348330a7e47d00427c54dd)