### PR TITLE
Add monthly income progress report endpoint

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/ReportsController.java
@@ -2,6 +2,7 @@ package com.monarchsolutions.sms.controller;
 
 import com.monarchsolutions.sms.dto.common.PageResult;
 import com.monarchsolutions.sms.dto.paymentRequests.UpdatePaymentRequest;
+import com.monarchsolutions.sms.dto.reports.MonthlyIncomeProgressResponse;
 import com.monarchsolutions.sms.dto.student.GetStudentDetails;
 import com.monarchsolutions.sms.service.ReportsService;
 import com.monarchsolutions.sms.service.StudentService;
@@ -97,6 +98,22 @@ public class ReportsController {
 			);
 
 			return ResponseEntity.ok(page);
+		} catch (Exception e) {
+			return ResponseEntity.badRequest().body(e.getMessage());
+		}
+	}
+
+	@RequirePermission(module = "tuitions", action = "r")
+	@GetMapping("/monthly-income-progress")
+	public ResponseEntity<?> getMonthlyIncomeProgress(
+		@RequestHeader("Authorization") String authHeader
+	) {
+		try {
+			String token = authHeader.replaceFirst("^Bearer\\s+", "");
+			Long tokenUserId = jwtUtil.extractUserId(token);
+
+			MonthlyIncomeProgressResponse response = reportsService.getMonthlyIncomeProgress(tokenUserId);
+			return ResponseEntity.ok(response);
 		} catch (Exception e) {
 			return ResponseEntity.badRequest().body(e.getMessage());
 		}

--- a/src/main/java/com/monarchsolutions/sms/dto/reports/MonthlyIncomeProgressResponse.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/reports/MonthlyIncomeProgressResponse.java
@@ -1,0 +1,34 @@
+package com.monarchsolutions.sms.dto.reports;
+
+import java.math.BigDecimal;
+
+public class MonthlyIncomeProgressResponse {
+
+    private BigDecimal monthIncomeTotal;
+    private BigDecimal monthGoalTotal;
+    private BigDecimal monthProgressPct;
+
+    public BigDecimal getMonthIncomeTotal() {
+        return monthIncomeTotal;
+    }
+
+    public void setMonthIncomeTotal(BigDecimal monthIncomeTotal) {
+        this.monthIncomeTotal = monthIncomeTotal;
+    }
+
+    public BigDecimal getMonthGoalTotal() {
+        return monthGoalTotal;
+    }
+
+    public void setMonthGoalTotal(BigDecimal monthGoalTotal) {
+        this.monthGoalTotal = monthGoalTotal;
+    }
+
+    public BigDecimal getMonthProgressPct() {
+        return monthProgressPct;
+    }
+
+    public void setMonthProgressPct(BigDecimal monthProgressPct) {
+        this.monthProgressPct = monthProgressPct;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/ReportsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/ReportsService.java
@@ -6,6 +6,7 @@ import com.monarchsolutions.sms.dto.reports.PaymentRequestDetailsResponseV2;
 import com.monarchsolutions.sms.dto.reports.PaymentRequestDetailsResponseV2.BreakdownEntry;
 import com.monarchsolutions.sms.dto.reports.PaymentRequestDetailsResponseV2.PaymentDetail;
 import com.monarchsolutions.sms.dto.reports.PaymentRequestDetailsResponseV2.PaymentInfoSummary;
+import com.monarchsolutions.sms.dto.reports.MonthlyIncomeProgressResponse;
 import com.monarchsolutions.sms.repository.ReportsRepository;
 
 import java.math.BigDecimal;
@@ -115,6 +116,12 @@ public class ReportsService {
             order_by,
             order_dir
         );
+    }
+
+
+    @Transactional(readOnly = true)
+    public MonthlyIncomeProgressResponse getMonthlyIncomeProgress(Long tokenUserId) throws SQLException {
+        return reportsRepository.getMonthlyIncomeProgress(tokenUserId);
     }
 
 


### PR DESCRIPTION
## Summary
- add DTO and repository method to fetch monthly income, goal, and progress values for the authenticated user’s schools
- expose a new reports endpoint that returns the monthly income progress data with tuition read permission

## Testing
- `mvn test` *(fails: unable to resolve spring-boot-starter-parent from Maven Central; 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e6e856dc833092a0b4f75463fc0e)