### PR TITLE
Add pending payment totals query endpoint

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/PaymentRequestController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PaymentRequestController.java
@@ -13,6 +13,7 @@ import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRecurrenceDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestScheduleDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.PendingPaymentSummaryDTO;
+import com.monarchsolutions.sms.dto.paymentRequests.PendingPaymentTotalsDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.StudentPaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.ValidatePaymentRequestExistence;
 import com.monarchsolutions.sms.annotation.RequirePermission;
@@ -171,6 +172,16 @@ public class PaymentRequestController {
         Long token_user_id = jwtUtil.extractUserId(token);
         PendingPaymentSummaryDTO pending = paymentRequestService.getPendingByStudent(token_user_id,studentId);
         return ResponseEntity.ok(pending);
+    }
+
+    @GetMapping("/pending-totals")
+    public ResponseEntity<PendingPaymentTotalsDTO> getPendingTotals(
+        @RequestHeader("Authorization") String authHeader
+    ) {
+        String token = authHeader.substring(7);
+        Long tokenUserId = jwtUtil.extractUserId(token);
+        PendingPaymentTotalsDTO totals = paymentRequestService.getPendingTotals(tokenUserId);
+        return ResponseEntity.ok(totals);
     }
 
     @GetMapping("/student-pending-payments")

--- a/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PendingPaymentTotalsDTO.java
+++ b/src/main/java/com/monarchsolutions/sms/dto/paymentRequests/PendingPaymentTotalsDTO.java
@@ -1,0 +1,32 @@
+package com.monarchsolutions.sms.dto.paymentRequests;
+
+import java.math.BigDecimal;
+
+public class PendingPaymentTotalsDTO {
+  private BigDecimal pendingTotalAmount;
+  private Long studentsWithPendingCount;
+
+  public PendingPaymentTotalsDTO(BigDecimal pendingTotalAmount, Long studentsWithPendingCount) {
+    this.pendingTotalAmount = pendingTotalAmount;
+    this.studentsWithPendingCount = studentsWithPendingCount;
+  }
+
+  public PendingPaymentTotalsDTO() {
+  }
+
+  public BigDecimal getPendingTotalAmount() {
+    return pendingTotalAmount;
+  }
+
+  public void setPendingTotalAmount(BigDecimal pendingTotalAmount) {
+    this.pendingTotalAmount = pendingTotalAmount;
+  }
+
+  public Long getStudentsWithPendingCount() {
+    return studentsWithPendingCount;
+  }
+
+  public void setStudentsWithPendingCount(Long studentsWithPendingCount) {
+    this.studentsWithPendingCount = studentsWithPendingCount;
+  }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/PaymentRequestService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PaymentRequestService.java
@@ -11,6 +11,7 @@ import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRecurrenceDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.CreatePaymentRequestScheduleDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.PendingPaymentSummaryDTO;
+import com.monarchsolutions.sms.dto.paymentRequests.PendingPaymentTotalsDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.StudentPaymentRequestDTO;
 import com.monarchsolutions.sms.dto.paymentRequests.ValidatePaymentRequestExistence;
 import com.monarchsolutions.sms.repository.PaymentRequestRepository;
@@ -81,5 +82,9 @@ public class PaymentRequestService {
 
   public List<StudentPaymentRequestDTO> getStudentPaymentRequests(Long studentId, String lang) {
     return paymentRequestRepository.getStudentPaymentRequests(studentId,lang);
+  }
+
+  public PendingPaymentTotalsDTO getPendingTotals(Long tokenUserId) {
+    return paymentRequestRepository.getPendingTotals(tokenUserId);
   }
 }


### PR DESCRIPTION
## Summary
- add DTO to return aggregated pending payment totals and student count
- implement repository and service methods to execute the pending totals query for the caller
- expose GET `/api/payment-requests/pending-totals` endpoint that returns the aggregated values using the caller token

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956eac97a2c83309cb02ecf94096725)