### PR TITLE
Add school-aware access to payment concepts query and update endpoint to pass token and school

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -24,8 +24,12 @@ public class CatalogController {
 
   @GetMapping("/payment-concepts")
   public ResponseEntity<List<PaymentConceptsDto>> paymentConcepts(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestParam(name = "school_id", required = false) Long schoolId,
           @RequestParam(defaultValue = "es") String lang) {
-      return ResponseEntity.ok(CatalogsService.getPaymentConcepts(lang));
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      return ResponseEntity.ok(CatalogsService.getPaymentConcepts(lang, tokenUserId, schoolId));
   }
 
   @GetMapping("/payment-statuses")

--- a/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentConceptsRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentConceptsRepository.java
@@ -14,12 +14,80 @@ public interface PaymentConceptsRepository extends JpaRepository<PaymentConcepts
   
   @Query(value = """
     SELECT
-      pt.payment_concept_id               AS id,
-      CASE WHEN :lang = 'en' THEN pt.name_en ELSE pt.name_es END           AS name,
+      pt.payment_concept_id AS id,
+      CASE WHEN :lang = 'en' THEN pt.name_en ELSE pt.name_es END AS name,
       CASE WHEN :lang = 'en' THEN pt.description_en ELSE pt.description_es END AS description
     FROM payment_concepts pt
-    ORDER BY pt.payment_concept_id
+    JOIN users u_call
+      ON u_call.user_id = :token_user_id
+    WHERE
+    (
+      /* =======================
+         CASO A: usuario SIN school_id (global/admin)
+         ======================= */
+      u_call.school_id IS NULL
+      AND (
+            :school_id IS NULL
+            OR pt.school_id = :school_id
+            OR pt.school_id IS NULL
+          )
+    )
+    OR
+    (
+      /* =======================
+         CASO B: usuario CON school_id
+         ======================= */
+
+      u_call.school_id IS NOT NULL
+      AND
+      (
+        /* Globales siempre */
+        pt.school_id IS NULL
+
+        /* Conceptos de escuelas accesibles */
+        OR pt.school_id IN (
+          SELECT school_id
+          FROM (
+            SELECT u_call.school_id AS school_id
+            UNION ALL
+            SELECT sc.school_id
+            FROM schools sc
+            WHERE sc.related_school_id = u_call.school_id
+          ) x
+          WHERE x.school_id IS NOT NULL
+        )
+      )
+      AND
+      (
+        /* Filtro opcional por escuela:
+           - si viene :school_id, solo aplica si está dentro del acceso del usuario
+           - si NO está dentro, cae a la escuela del usuario (safe default)
+        */
+        :school_id IS NULL
+        OR pt.school_id = (
+          CASE
+            WHEN :school_id IN (
+              SELECT school_id
+              FROM (
+                SELECT u_call.school_id AS school_id
+                UNION ALL
+                SELECT sc2.school_id
+                FROM schools sc2
+                WHERE sc2.related_school_id = u_call.school_id
+              ) y
+              WHERE y.school_id IS NOT NULL
+            )
+            THEN :school_id
+            ELSE u_call.school_id
+          END
+        )
+        OR pt.school_id IS NULL
+      )
+    )
+    ORDER BY pt.payment_concept_id DESC
     """,
     nativeQuery = true)
-  List<PaymentConceptsDto> findAllByLang(@Param("lang") String lang);
+  List<PaymentConceptsDto> findAllByLang(@Param("lang") String lang,
+      @Param("token_user_id") Long tokenUserId,
+      @Param("school_id") Long schoolId);
 }

--- a/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
@@ -35,8 +35,8 @@ public class CatalogsService {
   @Autowired
   private PlanModulesRepository planModulesRepository;
 
-  public List<PaymentConceptsDto> getPaymentConcepts(String lang) {
-      return paymentConceptsRepository.findAllByLang(lang);
+  public List<PaymentConceptsDto> getPaymentConcepts(String lang, Long tokenUserId, Long schoolId) {
+      return paymentConceptsRepository.findAllByLang(lang, tokenUserId, schoolId);
   }
 
   public List<PaymentStatusesDto> getPaymentStatuses(String lang) {


### PR DESCRIPTION
### Motivation

- Enforce school-based access control for payment concepts so results reflect the requesting user's school permissions.
- Allow optional `school_id` filtering but fall back safely to the user's school when appropriate.

### Description

- Replace the `PaymentConceptsRepository` native query with a school-aware SQL that joins `users` by `:token_user_id`, applies access rules, and accepts `:token_user_id` and `:school_id` parameters, ordering results by `payment_concept_id DESC`.
- Update the repository method signature to `findAllByLang` with parameters `@Param("lang")`, `@Param("token_user_id")`, and `@Param("school_id")`.
- Change `CatalogsService.getPaymentConcepts` to accept `lang`, `tokenUserId`, and `schoolId` and forward them to the repository via `findAllByLang`.
- Update the `CatalogController` `/payment-concepts` endpoint to read the `Authorization` header, extract the user id with `jwtUtil.extractUserId(token)`, accept optional `school_id` query param, and call the updated service method.

### Testing

- No automated tests were run for this change.
- Basic repository/controller wiring was verified by inspecting the updated source files locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641c6db35c8330b1b42ef192cd66dd)