### PR TITLE
Add school-aware filtering to PaymentThrough catalog and thread token/school parameters

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -40,8 +40,12 @@ public class CatalogController {
 
   @GetMapping("/payment-through")
   public ResponseEntity<List<PaymentThroughDto>> paymentThrough(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestParam(name = "school_id", required = false) Long schoolId,
           @RequestParam(defaultValue = "es") String lang) {
-      return ResponseEntity.ok(CatalogsService.getPaymentThrough(lang));
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      return ResponseEntity.ok(CatalogsService.getPaymentThrough(lang, tokenUserId, schoolId));
   }
 
   @GetMapping("/scholar-levels")

--- a/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
@@ -43,8 +43,8 @@ public class CatalogsService {
       return paymentStatusesRepository.findAllByLang(lang);
   }
 
-  public List<PaymentThroughDto> getPaymentThrough(String lang) {
-      return paymentThroughRepository.findAllByLang(lang);
+  public List<PaymentThroughDto> getPaymentThrough(String lang, Long tokenUserId, Long schoolId) {
+      return paymentThroughRepository.findAllByLang(lang, tokenUserId, schoolId);
   }
 
   public List<ScholarLevelsDto> getScholarLevels(String lang) {


### PR DESCRIPTION
### Motivation
- Apply a school-aware SQL query for the `payment_through` catalog so results respect the requesting user's `school_id`, related schools, and an optional `school_id` filter.
- Preserve language selection between English and Spanish for the catalog names using the `:lang` parameter.

### Description
- Replaced the repository query in `PaymentThroughRepository` with the provided SQL that joins `users u_call`, filters by `u_call.school_id` and optional `:school_id`, and orders by `pt.payment_through_id DESC`.
- Changed the repository method signature to `findAllByLang(@Param("lang") String lang, @Param("token_user_id") Long tokenUserId, @Param("school_id") Long schoolId)`.
- Updated `CatalogsService.getPaymentThrough` to accept `tokenUserId` and `schoolId` and forward them to the repository via `paymentThroughRepository.findAllByLang(...)`.
- Updated `CatalogController.paymentThrough` to require the `Authorization` header, accept optional `school_id`, extract the user id with `JwtUtil`, and call the updated service method.

### Testing
- No automated tests were executed for this change.
- Changes were compiled and committed locally (no CI run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641f1bd5d083309204f449f498f1f8)