### PR TITLE
Add update endpoints and stored-procedure repositories for payment concepts and payment-through

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/CatalogController.java
@@ -1,5 +1,6 @@
 package com.monarchsolutions.sms.controller;
 
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.catalogs.PaymentConceptsDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentStatusesDto;
 import com.monarchsolutions.sms.dto.catalogs.PaymentThroughDto;
@@ -8,6 +9,7 @@ import com.monarchsolutions.sms.dto.catalogs.PlanModuleDto;
 import com.monarchsolutions.sms.dto.catalogs.ScholarLevelsDto;
 import com.monarchsolutions.sms.service.CatalogsService;
 import com.monarchsolutions.sms.util.JwtUtil;
+import java.util.Map;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,32 @@ public class CatalogController {
       return ResponseEntity.ok(CatalogsService.getPaymentConcepts(lang, tokenUserId, schoolId));
   }
 
+  @RequirePermission(module = "payments", action = "c")
+  @PostMapping("/payment-concepts")
+  public ResponseEntity<Map<String, Object>> createPaymentConcept(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestBody Map<String, Object> payload,
+          @RequestParam(defaultValue = "es") String lang) throws Exception {
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      Map<String, Object> response = CatalogsService.createPaymentConcept(tokenUserId, payload, lang);
+      return ResponseEntity.ok(response);
+  }
+
+  @RequirePermission(module = "payments", action = "u")
+  @PutMapping("/payment-concepts")
+  public ResponseEntity<Map<String, Object>> updatePaymentConcept(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestParam("payment_concept_id") Long paymentConceptId,
+          @RequestBody Map<String, Object> payload,
+          @RequestParam(defaultValue = "es") String lang) throws Exception {
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      Map<String, Object> response =
+              CatalogsService.updatePaymentConcept(tokenUserId, paymentConceptId, payload, lang);
+      return ResponseEntity.ok(response);
+  }
+
   @GetMapping("/payment-statuses")
   public ResponseEntity<List<PaymentStatusesDto>> paymentStatuses(
           @RequestParam(defaultValue = "es") String lang) {
@@ -46,6 +74,32 @@ public class CatalogController {
       String token = authHeader.replaceFirst("^Bearer\\s+", "");
       Long tokenUserId = jwtUtil.extractUserId(token);
       return ResponseEntity.ok(CatalogsService.getPaymentThrough(lang, tokenUserId, schoolId));
+  }
+
+  @RequirePermission(module = "payments", action = "c")
+  @PostMapping("/payment-through")
+  public ResponseEntity<Map<String, Object>> createPaymentThrough(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestBody Map<String, Object> payload,
+          @RequestParam(defaultValue = "es") String lang) throws Exception {
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      Map<String, Object> response = CatalogsService.createPaymentThrough(tokenUserId, payload, lang);
+      return ResponseEntity.ok(response);
+  }
+
+  @RequirePermission(module = "payments", action = "u")
+  @PutMapping("/payment-through")
+  public ResponseEntity<Map<String, Object>> updatePaymentThrough(
+          @RequestHeader("Authorization") String authHeader,
+          @RequestParam("payment_through_id") Long paymentThroughId,
+          @RequestBody Map<String, Object> payload,
+          @RequestParam(defaultValue = "es") String lang) throws Exception {
+      String token = authHeader.replaceFirst("^Bearer\\s+", "");
+      Long tokenUserId = jwtUtil.extractUserId(token);
+      Map<String, Object> response =
+              CatalogsService.updatePaymentThrough(tokenUserId, paymentThroughId, payload, lang);
+      return ResponseEntity.ok(response);
   }
 
   @GetMapping("/scholar-levels")

--- a/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentConceptsProcedureRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentConceptsProcedureRepository.java
@@ -1,0 +1,87 @@
+package com.monarchsolutions.sms.repository.catalogs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PaymentConceptsProcedureRepository {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public Map<String, Object> createPaymentConcept(Long tokenUserId, Object payload, String lang) throws Exception {
+        String call = "{CALL createPaymentConcept(?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            stmt.setString(2, payloadJson);
+            stmt.setString(3, lang);
+
+            boolean hasResultSet = stmt.execute();
+            if (hasResultSet) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    if (rs.next()) {
+                        String jsonResponse = rs.getString(1);
+                        response = objectMapper.readValue(jsonResponse, Map.class);
+                    }
+                }
+            }
+        }
+
+        return response;
+    }
+
+    public Map<String, Object> updatePaymentConcept(Long tokenUserId, Long paymentConceptId, Object payload, String lang)
+            throws Exception {
+        String call = "{CALL updatePaymentConcept(?,?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            if (paymentConceptId != null) {
+                stmt.setInt(2, paymentConceptId.intValue());
+            } else {
+                stmt.setNull(2, Types.INTEGER);
+            }
+
+            stmt.setString(3, payloadJson);
+            stmt.setString(4, lang);
+
+            boolean hasResultSet = stmt.execute();
+            if (hasResultSet) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    if (rs.next()) {
+                        String jsonResponse = rs.getString(1);
+                        response = objectMapper.readValue(jsonResponse, Map.class);
+                    }
+                }
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentThroughProcedureRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentThroughProcedureRepository.java
@@ -1,0 +1,87 @@
+package com.monarchsolutions.sms.repository.catalogs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PaymentThroughProcedureRepository {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public Map<String, Object> createPaymentThrough(Long tokenUserId, Object payload, String lang) throws Exception {
+        String call = "{CALL createPaymentThrough(?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            stmt.setString(2, payloadJson);
+            stmt.setString(3, lang);
+
+            boolean hasResultSet = stmt.execute();
+            if (hasResultSet) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    if (rs.next()) {
+                        String jsonResponse = rs.getString(1);
+                        response = objectMapper.readValue(jsonResponse, Map.class);
+                    }
+                }
+            }
+        }
+
+        return response;
+    }
+
+    public Map<String, Object> updatePaymentThrough(Long tokenUserId, Long paymentThroughId, Object payload, String lang)
+            throws Exception {
+        String call = "{CALL updatePaymentThrough(?,?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            if (paymentThroughId != null) {
+                stmt.setInt(2, paymentThroughId.intValue());
+            } else {
+                stmt.setNull(2, Types.INTEGER);
+            }
+
+            stmt.setString(3, payloadJson);
+            stmt.setString(4, lang);
+
+            boolean hasResultSet = stmt.execute();
+            if (hasResultSet) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    if (rs.next()) {
+                        String jsonResponse = rs.getString(1);
+                        response = objectMapper.readValue(jsonResponse, Map.class);
+                    }
+                }
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/CatalogsService.java
@@ -8,8 +8,10 @@ import com.monarchsolutions.sms.dto.catalogs.PeriodOfTimeDto;
 import com.monarchsolutions.sms.dto.catalogs.PlanModuleDto;
 
 import com.monarchsolutions.sms.repository.catalogs.PaymentConceptsRepository;
+import com.monarchsolutions.sms.repository.catalogs.PaymentConceptsProcedureRepository;
 import com.monarchsolutions.sms.repository.catalogs.PaymentStatusesRepository;
 import com.monarchsolutions.sms.repository.catalogs.PaymentThroughRepository;
+import com.monarchsolutions.sms.repository.catalogs.PaymentThroughProcedureRepository;
 import com.monarchsolutions.sms.repository.catalogs.ScholarLevelsRepository;
 import com.monarchsolutions.sms.repository.catalogs.PeriodsOfTimeRepository;
 import com.monarchsolutions.sms.repository.catalogs.PlanModulesRepository;
@@ -18,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class CatalogsService {
@@ -25,9 +28,13 @@ public class CatalogsService {
   @Autowired
   private PaymentConceptsRepository paymentConceptsRepository;
   @Autowired
+  private PaymentConceptsProcedureRepository paymentConceptsProcedureRepository;
+  @Autowired
   private PaymentStatusesRepository paymentStatusesRepository;
   @Autowired
   private PaymentThroughRepository paymentThroughRepository;
+  @Autowired
+  private PaymentThroughProcedureRepository paymentThroughProcedureRepository;
   @Autowired
   private ScholarLevelsRepository scholarLevelsRepository;
   @Autowired
@@ -39,12 +46,30 @@ public class CatalogsService {
       return paymentConceptsRepository.findAllByLang(lang, tokenUserId, schoolId);
   }
 
+  public Map<String, Object> createPaymentConcept(Long tokenUserId, Object payload, String lang) throws Exception {
+      return paymentConceptsProcedureRepository.createPaymentConcept(tokenUserId, payload, lang);
+  }
+
+  public Map<String, Object> updatePaymentConcept(Long tokenUserId, Long paymentConceptId, Object payload, String lang)
+          throws Exception {
+      return paymentConceptsProcedureRepository.updatePaymentConcept(tokenUserId, paymentConceptId, payload, lang);
+  }
+
   public List<PaymentStatusesDto> getPaymentStatuses(String lang) {
       return paymentStatusesRepository.findAllByLang(lang);
   }
 
   public List<PaymentThroughDto> getPaymentThrough(String lang, Long tokenUserId, Long schoolId) {
       return paymentThroughRepository.findAllByLang(lang, tokenUserId, schoolId);
+  }
+
+  public Map<String, Object> createPaymentThrough(Long tokenUserId, Object payload, String lang) throws Exception {
+      return paymentThroughProcedureRepository.createPaymentThrough(tokenUserId, payload, lang);
+  }
+
+  public Map<String, Object> updatePaymentThrough(Long tokenUserId, Long paymentThroughId, Object payload, String lang)
+          throws Exception {
+      return paymentThroughProcedureRepository.updatePaymentThrough(tokenUserId, paymentThroughId, payload, lang);
   }
 
   public List<ScholarLevelsDto> getScholarLevels(String lang) {


### PR DESCRIPTION
### Motivation
- Expose the stored procedures `updatePaymentConcept`, `createPaymentThrough`, and `updatePaymentThrough` through the API so clients can create/update payment catalogs.
- Ensure calls to these procedures run with the token user id extracted from JWT and enforce permissions before allowing create/update operations.
- Use JDBC `CallableStatement` repositories to invoke SPs and parse the JSON responses returned by the procedures.
- Wire the service and controller layers so the new SP-backed operations follow existing catalog patterns.

### Description
- Added `PaymentThroughProcedureRepository` with `createPaymentThrough` and `updatePaymentThrough` implementations that call the corresponding stored procedures and parse the JSON result with `ObjectMapper`.
- Added `updatePaymentConcept` to `PaymentConceptsProcedureRepository` to call the `updatePaymentConcept` stored procedure and return the parsed JSON response.
- Wired new service methods in `CatalogsService` and added controller endpoints `PUT /api/catalog/payment-concepts`, `POST /api/catalog/payment-through`, and `PUT /api/catalog/payment-through` with `@RequirePermission` annotations and token extraction via `JwtUtil`.
- Followed existing null-handling and result-set parsing patterns for `tokenUserId` and id parameters when invoking the SPs using `CallableStatement`.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69642cd2b56483309c581bcd2dd68baa)