### PR TITLE
Use StoredProcedureQuery/getResultList for PaymentConcept and PaymentThrough create/update

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentConceptsProcedureRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/catalogs/PaymentConceptsProcedureRepository.java
@@ -1,87 +1,92 @@
 package com.monarchsolutions.sms.repository.catalogs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Types;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import javax.sql.DataSource;
+import java.util.List;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.ParameterMode;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.StoredProcedureQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class PaymentConceptsProcedureRepository {
 
-    @Autowired
-    private DataSource dataSource;
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Autowired
     private ObjectMapper objectMapper;
 
     public Map<String, Object> createPaymentConcept(Long tokenUserId, Object payload, String lang) throws Exception {
-        String call = "{CALL createPaymentConcept(?,?,?)}";
-        Map<String, Object> response = new LinkedHashMap<>();
         String payloadJson = objectMapper.writeValueAsString(payload);
 
-        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
-            if (tokenUserId != null) {
-                stmt.setInt(1, tokenUserId.intValue());
-            } else {
-                stmt.setNull(1, Types.INTEGER);
-            }
+        StoredProcedureQuery query = entityManager.createStoredProcedureQuery("createPaymentConcept");
+        query.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter(2, String.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter(3, String.class, ParameterMode.IN);
 
-            stmt.setString(2, payloadJson);
-            stmt.setString(3, lang);
+        query.setParameter(1, tokenUserId != null ? tokenUserId.intValue() : null);
+        query.setParameter(2, payloadJson);
+        query.setParameter(3, lang);
 
-            boolean hasResultSet = stmt.execute();
-            if (hasResultSet) {
-                try (ResultSet rs = stmt.getResultSet()) {
-                    if (rs.next()) {
-                        String jsonResponse = rs.getString(1);
-                        response = objectMapper.readValue(jsonResponse, Map.class);
-                    }
-                }
-            }
-        }
-
-        return response;
+        query.execute();
+        return readResponse(query.getResultList());
     }
 
     public Map<String, Object> updatePaymentConcept(Long tokenUserId, Long paymentConceptId, Object payload, String lang)
             throws Exception {
-        String call = "{CALL updatePaymentConcept(?,?,?,?)}";
-        Map<String, Object> response = new LinkedHashMap<>();
         String payloadJson = objectMapper.writeValueAsString(payload);
 
-        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
-            if (tokenUserId != null) {
-                stmt.setInt(1, tokenUserId.intValue());
-            } else {
-                stmt.setNull(1, Types.INTEGER);
-            }
+        StoredProcedureQuery query = entityManager.createStoredProcedureQuery("updatePaymentConcept");
+        query.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter(2, Integer.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter(3, String.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter(4, String.class, ParameterMode.IN);
 
-            if (paymentConceptId != null) {
-                stmt.setInt(2, paymentConceptId.intValue());
-            } else {
-                stmt.setNull(2, Types.INTEGER);
-            }
+        query.setParameter(1, tokenUserId != null ? tokenUserId.intValue() : null);
+        query.setParameter(2, paymentConceptId != null ? paymentConceptId.intValue() : null);
+        query.setParameter(3, payloadJson);
+        query.setParameter(4, lang);
 
-            stmt.setString(3, payloadJson);
-            stmt.setString(4, lang);
+        query.execute();
+        return readResponse(query.getResultList());
+    }
 
-            boolean hasResultSet = stmt.execute();
-            if (hasResultSet) {
-                try (ResultSet rs = stmt.getResultSet()) {
-                    if (rs.next()) {
-                        String jsonResponse = rs.getString(1);
-                        response = objectMapper.readValue(jsonResponse, Map.class);
-                    }
-                }
-            }
+    private Map<String, Object> readResponse(List<?> results) throws Exception {
+        Map<String, Object> response = new LinkedHashMap<>();
+        if (results == null || results.isEmpty()) {
+            return response;
         }
 
-        return response;
+        Object last = results.get(results.size() - 1);
+        Object payload = unwrapPayload(last);
+        if (payload == null) {
+            return response;
+        }
+
+        if (payload instanceof Map<?, ?> mapPayload) {
+            response.putAll((Map<String, Object>) mapPayload);
+            return response;
+        }
+
+        String jsonResponse = payload.toString();
+        if (jsonResponse == null || jsonResponse.isBlank()) {
+            return response;
+        }
+
+        return objectMapper.readValue(jsonResponse, Map.class);
+    }
+
+    private Object unwrapPayload(Object payload) {
+        if (payload instanceof Object[] arrayPayload) {
+            if (arrayPayload.length == 0) {
+                return null;
+            }
+            return arrayPayload[0];
+        }
+        return payload;
     }
 }


### PR DESCRIPTION
### Motivation
- Stored procedures for `createPaymentConcept`, `updatePaymentConcept`, `createPaymentThrough` and `updatePaymentThrough` are returning multiple result sets and sometimes an `Object[]`, so existing JDBC handling only read the first result and missed the real payload.
- Switch to `StoredProcedureQuery` with `getResultList()` so we can collect all results and pick the actual one we need.
- Normalize handling so the code unwraps `Object[]` rows and supports both direct `Map` payloads and JSON string payloads.
- Simplify code by moving away from low-level `CallableStatement`/`ResultSet` in these repositories to use the `EntityManager`.

### Description
- Replaced JDBC `DataSource`/`CallableStatement` usage in `PaymentConceptsProcedureRepository` and `PaymentThroughProcedureRepository` with `EntityManager` + `StoredProcedureQuery` and registered parameters with `ParameterMode.IN`.
- After `query.execute()` the code now calls `query.getResultList()` and reads the last element returned to obtain the real SP response.
- Added `readResponse(List<?>)` and `unwrapPayload(Object)` helper methods to extract the payload from `Object[]` or `Map` and to parse JSON responses via `objectMapper` into `Map<String,Object>`.
- Preserved existing public method signatures (`createPaymentConcept`, `updatePaymentConcept`, `createPaymentThrough`, `updatePaymentThrough`) and return types while changing internal SP invocation and result parsing.

### Testing
- No automated tests were executed for this change.
- Basic compile/commit performed in the working branch and files were updated without errors.
- Manual runtime validation is recommended against the database SPs that return multiple result sets to confirm correct payload extraction.
- If available, run the project's test suite and integration tests that exercise these stored procedures to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964413061888330a37c8eeac2c94153)