### PR TITLE
Add role create/update endpoints via stored procedures

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/RoleController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/RoleController.java
@@ -1,11 +1,13 @@
 package com.monarchsolutions.sms.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import com.monarchsolutions.sms.util.JwtUtil;
+import com.monarchsolutions.sms.annotation.RequirePermission;
 import com.monarchsolutions.sms.dto.roles.RolesListResponse;
 import com.monarchsolutions.sms.service.RoleService;
 
@@ -34,6 +36,31 @@ public class RoleController {
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
+    }
+
+    @RequirePermission(module = "roles", action = "c")
+    @PostMapping("/create")
+    public ResponseEntity<Map<String, Object>> createRole(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody Map<String, Object> payload,
+            @RequestParam(defaultValue = "es") String lang) throws Exception {
+        String token = authHeader.replaceFirst("^Bearer\\s+", "");
+        Long tokenUserId = jwtUtil.extractUserId(token);
+        Map<String, Object> response = roleService.createRole(tokenUserId, payload, lang);
+        return ResponseEntity.ok(response);
+    }
+
+    @RequirePermission(module = "roles", action = "u")
+    @PutMapping("/update")
+    public ResponseEntity<Map<String, Object>> updateRole(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestParam("role_id") Long roleId,
+            @RequestBody Map<String, Object> payload,
+            @RequestParam(defaultValue = "es") String lang) throws Exception {
+        String token = authHeader.replaceFirst("^Bearer\\s+", "");
+        Long tokenUserId = jwtUtil.extractUserId(token);
+        Map<String, Object> response = roleService.updateRole(tokenUserId, roleId, payload, lang);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/monarchsolutions/sms/repository/RoleProcedureRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/RoleProcedureRepository.java
@@ -1,0 +1,97 @@
+package com.monarchsolutions.sms.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RoleProcedureRepository {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public Map<String, Object> createRole(Long tokenUserId, Object payload, String lang) throws Exception {
+        String call = "{CALL createRole(?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            stmt.setString(2, payloadJson);
+            stmt.setString(3, lang);
+
+            response = readResponse(stmt);
+        }
+
+        return response;
+    }
+
+    public Map<String, Object> updateRole(Long tokenUserId, Long roleId, Object payload, String lang) throws Exception {
+        String call = "{CALL updateRole(?,?,?,?)}";
+        Map<String, Object> response = new LinkedHashMap<>();
+        String payloadJson = objectMapper.writeValueAsString(payload);
+
+        try (Connection conn = dataSource.getConnection(); CallableStatement stmt = conn.prepareCall(call)) {
+            if (tokenUserId != null) {
+                stmt.setInt(1, tokenUserId.intValue());
+            } else {
+                stmt.setNull(1, Types.INTEGER);
+            }
+
+            if (roleId != null) {
+                stmt.setInt(2, roleId.intValue());
+            } else {
+                stmt.setNull(2, Types.INTEGER);
+            }
+
+            stmt.setString(3, payloadJson);
+            stmt.setString(4, lang);
+
+            response = readResponse(stmt);
+        }
+
+        return response;
+    }
+
+    private Map<String, Object> readResponse(CallableStatement stmt) throws SQLException {
+        Map<String, Object> response = new LinkedHashMap<>();
+
+        boolean hasResultSet = stmt.execute();
+        if (!hasResultSet) {
+            return response;
+        }
+
+        try (ResultSet rs = stmt.getResultSet()) {
+            if (!rs.next()) {
+                return response;
+            }
+
+            String jsonResponse = rs.getString(1);
+            if (jsonResponse == null || jsonResponse.isBlank()) {
+                return response;
+            }
+
+            response = objectMapper.readValue(jsonResponse, Map.class);
+        } catch (Exception ex) {
+            throw new SQLException("Failed to parse stored procedure response", ex);
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/RoleService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/RoleService.java
@@ -3,11 +3,13 @@ package com.monarchsolutions.sms.service;
 import com.monarchsolutions.sms.dto.roles.RolesListResponse;
 import com.monarchsolutions.sms.entity.Role;
 import com.monarchsolutions.sms.repository.RoleEntityRepository;
+import com.monarchsolutions.sms.repository.RoleProcedureRepository;
 import com.monarchsolutions.sms.repository.RoleRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.List;
 
 @Service
@@ -19,6 +21,9 @@ public class RoleService {
     @Autowired
     private RoleEntityRepository roleEntityRepository;
 
+    @Autowired
+    private RoleProcedureRepository roleProcedureRepository;
+
     public List<RolesListResponse> getRoles(Long token_user_id, Long school_id, String lang, int status_filter){
         return roleRepository.getRoles(token_user_id, school_id, lang, status_filter);
     }
@@ -26,5 +31,13 @@ public class RoleService {
     public List<Role> getRolesForUser(Long tokenUserId, String searchTerm, boolean onlyActive, String lang) {
         String sanitizedSearch = (searchTerm == null || searchTerm.isBlank()) ? null : searchTerm;
         return roleEntityRepository.findRolesForUserSchools(tokenUserId, sanitizedSearch, onlyActive, lang);
+    }
+
+    public Map<String, Object> createRole(Long tokenUserId, Object payload, String lang) throws Exception {
+        return roleProcedureRepository.createRole(tokenUserId, payload, lang);
+    }
+
+    public Map<String, Object> updateRole(Long tokenUserId, Long roleId, Object payload, String lang) throws Exception {
+        return roleProcedureRepository.updateRole(tokenUserId, roleId, payload, lang);
     }
 }


### PR DESCRIPTION
### Motivation

- Provide API endpoints to create and update roles by invoking existing stored procedures `createRole` and `updateRole` and enforce permission checks.
- Allow controllers and services to pass JSON payloads to the DB procedures and return structured JSON responses.

### Description

- Added a new repository `RoleProcedureRepository` that calls the stored procedures and parses JSON responses using `ObjectMapper` (new file `src/main/java/com/monarchsolutions/sms/repository/RoleProcedureRepository.java`).
- Exposed `createRole` and `updateRole` operations in `RoleService` which delegate to `RoleProcedureRepository` (modified `src/main/java/com/monarchsolutions/sms/service/RoleService.java`).
- Added API endpoints `POST /api/roles/create` and `PUT /api/roles/update` in `RoleController`, extracting the token user id with `JwtUtil` and protecting routes with `@RequirePermission(module = "roles", action = "c"/"u")` (modified `src/main/java/com/monarchsolutions/sms/controller/RoleController.java`).
- The endpoints accept a JSON payload as `Map<String,Object>` and forward it to the stored procedures; repository handles nullable token/role id parameters and returns parsed JSON as `Map<String,Object>`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6fb680788330bb716ac16008f823)