### PR TITLE
Add endpoint to return selected school's commercial name

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/controller/SchoolController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/SchoolController.java
@@ -219,6 +219,17 @@ public class SchoolController {
 		return ResponseEntity.ok(school_image);
 	}
 
+	@RequirePermission(module = "schools", action = "r")
+	@GetMapping("/commercial-name")
+	public ResponseEntity<String> getCommercialName(
+		@RequestHeader("Authorization") String authHeader
+	) {
+		String token = authHeader.substring(7);
+		Long tokenSchoolId = jwtUtil.extractSchoolId(token);
+		String commercialName = schoolService.getSchoolCommercialName(tokenSchoolId);
+		return ResponseEntity.ok(commercialName);
+	}
+
 	@GetMapping("/user-school")
 	public ResponseEntity<String> getuserSchool(@RequestHeader("Authorization") String authHeader) {
 		// 2) Extract the token and get userId

--- a/src/main/java/com/monarchsolutions/sms/repository/SchoolRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/SchoolRepository.java
@@ -368,6 +368,29 @@ public class SchoolRepository {
 		throw new IllegalStateException("Unexpected type for image: " + single.getClass());
 	}
 
+	public String getSchoolCommercialName(Long tokenSchoolId) {
+		var sql = """
+			SELECT s.commercial_name
+			FROM edupilot.schools s
+			WHERE s.school_id = :token_school_id;
+		""";
+
+		Object single = entityManager
+			.createNativeQuery(sql)
+			.setParameter("token_school_id", tokenSchoolId)
+			.getSingleResult();
+
+		if (single == null) {
+			return null;
+		}
+
+		if (single instanceof String name) {
+			return name;
+		}
+
+		throw new IllegalStateException("Unexpected type for commercial_name: " + single.getClass());
+	}
+
 	public Map<String, Object> getSchoolDetails(Long tokenUserId, Long schoolId, String lang) throws SQLException {
 		Map<String, Object> response = new LinkedHashMap<>();
 

--- a/src/main/java/com/monarchsolutions/sms/service/SchoolService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/SchoolService.java
@@ -145,4 +145,8 @@ public class SchoolService {
 		return schoolRepository.getUserSchool(token_user_id);
 	}
 
+	public String getSchoolCommercialName(Long tokenSchoolId) {
+		return schoolRepository.getSchoolCommercialName(tokenSchoolId);
+	}
+
 }


### PR DESCRIPTION
### Motivation
- Provide a lightweight API to return the `commercial_name` for the school currently selected in the user's JWT (using `jwtUtil.extractSchoolId(token)`).

### Description
- Add `getSchoolCommercialName(Long)` in `SchoolRepository` which executes a native query against `edupilot.schools` to read `commercial_name`, expose `getSchoolCommercialName(Long)` in `SchoolService` and add a new controller endpoint `GET /api/schools/commercial-name` in `SchoolController` that extracts the token school id with `jwtUtil.extractSchoolId(token)` and returns the commercial name (endpoint guarded with `@RequirePermission(module = "schools", action = "r")`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d166e129883308b536444b273255d)