### PR TITLE
Add manual legacy payments ETL with legacy datasource, repo, service and admin endpoint

### DIFF
--- a/src/main/java/com/monarchsolutions/sms/config/LegacyDataSourceConfig.java
+++ b/src/main/java/com/monarchsolutions/sms/config/LegacyDataSourceConfig.java
@@ -1,0 +1,32 @@
+package com.monarchsolutions.sms.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Configuration
+public class LegacyDataSourceConfig {
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.legacy")
+    public DataSourceProperties legacyDataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean(name = "legacyDataSource")
+    public DataSource legacyDataSource(
+            @Qualifier("legacyDataSourceProperties") DataSourceProperties legacyDataSourceProperties
+    ) {
+        return legacyDataSourceProperties.initializeDataSourceBuilder().build();
+    }
+
+    @Bean(name = "legacyJdbcTemplate")
+    public JdbcTemplate legacyJdbcTemplate(@Qualifier("legacyDataSource") DataSource legacyDataSource) {
+        return new JdbcTemplate(legacyDataSource);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/controller/PaymentsLegacyEtlController.java
+++ b/src/main/java/com/monarchsolutions/sms/controller/PaymentsLegacyEtlController.java
@@ -1,0 +1,31 @@
+package com.monarchsolutions.sms.controller;
+
+import com.monarchsolutions.sms.etl.PaymentsLegacyEtlResult;
+import com.monarchsolutions.sms.service.PaymentsLegacyEtlService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/etl/payments")
+public class PaymentsLegacyEtlController {
+
+    private final PaymentsLegacyEtlService paymentsLegacyEtlService;
+
+    public PaymentsLegacyEtlController(PaymentsLegacyEtlService paymentsLegacyEtlService) {
+        this.paymentsLegacyEtlService = paymentsLegacyEtlService;
+    }
+
+    @PostMapping("/run")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<PaymentsLegacyEtlResult> runEtl(
+            @RequestParam("sourceCode") String sourceCode,
+            @RequestParam(name = "batchSize", defaultValue = "500") int batchSize
+    ) {
+        PaymentsLegacyEtlResult result = paymentsLegacyEtlService.run(sourceCode, batchSize);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/etl/LegacyPagoRecord.java
+++ b/src/main/java/com/monarchsolutions/sms/etl/LegacyPagoRecord.java
@@ -1,0 +1,96 @@
+package com.monarchsolutions.sms.etl;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class LegacyPagoRecord {
+
+    private final long idPago;
+    private final Long idAlumno;
+    private final String concepto;
+    private final BigDecimal monto;
+    private final LocalDate fechaRegistro;
+    private final LocalDate fechaPago;
+    private final String formaPago;
+    private final String estatusPago;
+    private final String comprobante;
+    private final String observaciones;
+    private final Long idUsuarioAprobo;
+    private final LocalDate fechaAprobacion;
+
+    public LegacyPagoRecord(
+            long idPago,
+            Long idAlumno,
+            String concepto,
+            BigDecimal monto,
+            LocalDate fechaRegistro,
+            LocalDate fechaPago,
+            String formaPago,
+            String estatusPago,
+            String comprobante,
+            String observaciones,
+            Long idUsuarioAprobo,
+            LocalDate fechaAprobacion
+    ) {
+        this.idPago = idPago;
+        this.idAlumno = idAlumno;
+        this.concepto = concepto;
+        this.monto = monto;
+        this.fechaRegistro = fechaRegistro;
+        this.fechaPago = fechaPago;
+        this.formaPago = formaPago;
+        this.estatusPago = estatusPago;
+        this.comprobante = comprobante;
+        this.observaciones = observaciones;
+        this.idUsuarioAprobo = idUsuarioAprobo;
+        this.fechaAprobacion = fechaAprobacion;
+    }
+
+    public long getIdPago() {
+        return idPago;
+    }
+
+    public Long getIdAlumno() {
+        return idAlumno;
+    }
+
+    public String getConcepto() {
+        return concepto;
+    }
+
+    public BigDecimal getMonto() {
+        return monto;
+    }
+
+    public LocalDate getFechaRegistro() {
+        return fechaRegistro;
+    }
+
+    public LocalDate getFechaPago() {
+        return fechaPago;
+    }
+
+    public String getFormaPago() {
+        return formaPago;
+    }
+
+    public String getEstatusPago() {
+        return estatusPago;
+    }
+
+    public String getComprobante() {
+        return comprobante;
+    }
+
+    public String getObservaciones() {
+        return observaciones;
+    }
+
+    public Long getIdUsuarioAprobo() {
+        return idUsuarioAprobo;
+    }
+
+    public LocalDate getFechaAprobacion() {
+        return fechaAprobacion;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/etl/LegacyPagoRowMapper.java
+++ b/src/main/java/com/monarchsolutions/sms/etl/LegacyPagoRowMapper.java
@@ -1,0 +1,27 @@
+package com.monarchsolutions.sms.etl;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.springframework.jdbc.core.RowMapper;
+
+public class LegacyPagoRowMapper implements RowMapper<LegacyPagoRecord> {
+
+    @Override
+    public LegacyPagoRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new LegacyPagoRecord(
+                rs.getLong("idPago"),
+                rs.getObject("idAlumno", Long.class),
+                rs.getString("concepto"),
+                rs.getBigDecimal("monto"),
+                rs.getObject("fechaRegistro", java.time.LocalDate.class),
+                rs.getObject("fechaPago", java.time.LocalDate.class),
+                rs.getString("formaPago"),
+                rs.getString("estatusPago"),
+                rs.getString("comprobante"),
+                rs.getString("observaciones"),
+                rs.getObject("idUsuarioAprobo", Long.class),
+                rs.getObject("fechaAprobacion", java.time.LocalDate.class)
+        );
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/etl/PaymentsLegacyEtlResult.java
+++ b/src/main/java/com/monarchsolutions/sms/etl/PaymentsLegacyEtlResult.java
@@ -1,0 +1,58 @@
+package com.monarchsolutions.sms.etl;
+
+public class PaymentsLegacyEtlResult {
+
+    private final long lastLegacyPkBefore;
+    private final long lastLegacyPkAfter;
+    private final long rowsRead;
+    private final long rowsInserted;
+    private final long rowsSkipped;
+    private final long issuesCreated;
+    private final long durationMs;
+
+    public PaymentsLegacyEtlResult(
+            long lastLegacyPkBefore,
+            long lastLegacyPkAfter,
+            long rowsRead,
+            long rowsInserted,
+            long rowsSkipped,
+            long issuesCreated,
+            long durationMs
+    ) {
+        this.lastLegacyPkBefore = lastLegacyPkBefore;
+        this.lastLegacyPkAfter = lastLegacyPkAfter;
+        this.rowsRead = rowsRead;
+        this.rowsInserted = rowsInserted;
+        this.rowsSkipped = rowsSkipped;
+        this.issuesCreated = issuesCreated;
+        this.durationMs = durationMs;
+    }
+
+    public long getLastLegacyPkBefore() {
+        return lastLegacyPkBefore;
+    }
+
+    public long getLastLegacyPkAfter() {
+        return lastLegacyPkAfter;
+    }
+
+    public long getRowsRead() {
+        return rowsRead;
+    }
+
+    public long getRowsInserted() {
+        return rowsInserted;
+    }
+
+    public long getRowsSkipped() {
+        return rowsSkipped;
+    }
+
+    public long getIssuesCreated() {
+        return issuesCreated;
+    }
+
+    public long getDurationMs() {
+        return durationMs;
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/repository/etl/PaymentsLegacyEtlRepository.java
+++ b/src/main/java/com/monarchsolutions/sms/repository/etl/PaymentsLegacyEtlRepository.java
@@ -1,0 +1,227 @@
+package com.monarchsolutions.sms.repository.etl;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PaymentsLegacyEtlRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public PaymentsLegacyEtlRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public long findLegacySourceId(String sourceCode) {
+        return jdbcTemplate.queryForObject(
+                "SELECT legacy_source_id FROM legacy_sources WHERE source_code = ?",
+                Long.class,
+                sourceCode
+        );
+    }
+
+    public long getOrCreateWatermark(long legacySourceId, String jobName) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT last_legacy_pk FROM etl_watermarks WHERE legacy_source_id = ? AND job_name = ?",
+                    Long.class,
+                    legacySourceId,
+                    jobName
+            );
+        } catch (EmptyResultDataAccessException ex) {
+            jdbcTemplate.update(
+                    "INSERT INTO etl_watermarks (legacy_source_id, job_name, last_legacy_pk) VALUES (?, ?, ?)",
+                    legacySourceId,
+                    jobName,
+                    0
+            );
+            return 0;
+        }
+    }
+
+    public void updateWatermark(long legacySourceId, String jobName, long lastLegacyPk) {
+        jdbcTemplate.update(
+                "UPDATE etl_watermarks SET last_legacy_pk = ? WHERE legacy_source_id = ? AND job_name = ?",
+                lastLegacyPk,
+                legacySourceId,
+                jobName
+        );
+    }
+
+    public long createEtlRun(long legacySourceId, String jobName, long lastPkBefore, Instant startedAt) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO etl_runs (legacy_source_id, job_name, started_at, status, last_legacy_pk_before) " +
+                            "VALUES (?, ?, ?, ?, ?)",
+                    Statement.RETURN_GENERATED_KEYS
+            );
+            statement.setLong(1, legacySourceId);
+            statement.setString(2, jobName);
+            statement.setTimestamp(3, Timestamp.from(startedAt));
+            statement.setString(4, "RUNNING");
+            statement.setLong(5, lastPkBefore);
+            return statement;
+        }, keyHolder);
+        Number key = keyHolder.getKey();
+        return key == null ? 0L : key.longValue();
+    }
+
+    public void finishEtlRun(
+            long etlRunId,
+            String status,
+            long lastPkAfter,
+            long rowsRead,
+            long rowsInserted,
+            long rowsSkipped,
+            long issuesCreated,
+            long durationMs,
+            Instant finishedAt
+    ) {
+        jdbcTemplate.update(
+                "UPDATE etl_runs SET finished_at = ?, status = ?, last_legacy_pk_after = ?, rows_read = ?, " +
+                        "rows_inserted = ?, rows_skipped = ?, issues_created = ?, duration_ms = ? WHERE etl_run_id = ?",
+                Timestamp.from(finishedAt),
+                status,
+                lastPkAfter,
+                rowsRead,
+                rowsInserted,
+                rowsSkipped,
+                issuesCreated,
+                durationMs,
+                etlRunId
+        );
+    }
+
+    public Optional<Long> findStudentId(long legacySourceId, long legacyStudentId) {
+        return optionalLong(
+                "SELECT student_id FROM student_legacy_map WHERE legacy_source_id = ? AND legacy_student_id = ?",
+                legacySourceId,
+                legacyStudentId
+        );
+    }
+
+    public Optional<Long> findPaymentConceptId(long legacySourceId, String normalizedKey) {
+        return optionalLong(
+                "SELECT payment_concept_id FROM payment_concept_legacy_map " +
+                        "WHERE legacy_source_id = ? AND legacy_concept_key_normalized = ?",
+                legacySourceId,
+                normalizedKey
+        );
+    }
+
+    public Optional<Long> findPaymentThroughId(long legacySourceId, String normalizedKey) {
+        return optionalLong(
+                "SELECT payment_through_id FROM payment_through_legacy_map " +
+                        "WHERE legacy_source_id = ? AND legacy_payment_through_key_normalized = ?",
+                legacySourceId,
+                normalizedKey
+        );
+    }
+
+    public Optional<Long> findUserIdFromLegacyUserMap(long legacySourceId, long legacyUserId) {
+        return optionalLong(
+                "SELECT user_id FROM user_legacy_map WHERE legacy_source_id = ? AND legacy_user_id = ?",
+                legacySourceId,
+                legacyUserId
+        );
+    }
+
+    public Optional<Long> findUserIdByEmail(String email) {
+        return optionalLong("SELECT user_id FROM users WHERE email = ?", email);
+    }
+
+    public void insertUserLegacyMap(long legacySourceId, long legacyUserId, String legacyEmail, long userId) {
+        jdbcTemplate.update(
+                "INSERT INTO user_legacy_map (legacy_source_id, legacy_user_id, legacy_email, user_id) " +
+                        "VALUES (?, ?, ?, ?)",
+                legacySourceId,
+                legacyUserId,
+                legacyEmail,
+                userId
+        );
+    }
+
+    public void insertMappingIssue(
+            long legacySourceId,
+            String jobName,
+            long legacyPk,
+            String issueType,
+            String issueDetails
+    ) {
+        jdbcTemplate.update(
+                "INSERT INTO etl_mapping_issues (legacy_source_id, job_name, legacy_pk, issue_type, issue_details, created_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                legacySourceId,
+                jobName,
+                legacyPk,
+                issueType,
+                issueDetails,
+                Timestamp.from(Instant.now())
+        );
+    }
+
+    public int insertPayment(
+            long studentId,
+            long paymentConceptId,
+            Integer paymentStatusId,
+            Long validatedByUserId,
+            LocalDate validatedAt,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            String comments,
+            Long paymentThroughId,
+            String receiptFileName,
+            LocalDate paymentDate,
+            long legacySourceId,
+            long legacyPaymentId,
+            java.math.BigDecimal amount
+    ) {
+        return jdbcTemplate.update(
+                "INSERT INTO payments (" +
+                        "student_id, payment_concept_id, payment_month, amount, payment_status_id, " +
+                        "validated_by_user_id, validated_at, created_at, updated_at, comments, " +
+                        "payment_request_id, payment_through_id, receipt_path, receipt_file_name, payment_date, " +
+                        "legacy_source_id, legacy_payment_id" +
+                        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+                        "ON DUPLICATE KEY UPDATE updated_at = VALUES(updated_at)",
+                studentId,
+                paymentConceptId,
+                null,
+                amount,
+                paymentStatusId,
+                validatedByUserId,
+                validatedAt == null ? null : java.sql.Date.valueOf(validatedAt),
+                Timestamp.valueOf(createdAt),
+                Timestamp.valueOf(updatedAt),
+                comments,
+                null,
+                paymentThroughId,
+                null,
+                receiptFileName,
+                paymentDate == null ? null : java.sql.Date.valueOf(paymentDate),
+                legacySourceId,
+                legacyPaymentId
+        );
+    }
+
+    private Optional<Long> optionalLong(String sql, Object... args) {
+        try {
+            Long value = jdbcTemplate.queryForObject(sql, Long.class, args);
+            return Optional.ofNullable(value);
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/monarchsolutions/sms/service/PaymentsLegacyEtlService.java
+++ b/src/main/java/com/monarchsolutions/sms/service/PaymentsLegacyEtlService.java
@@ -1,0 +1,375 @@
+package com.monarchsolutions.sms.service;
+
+import com.monarchsolutions.sms.etl.LegacyPagoRecord;
+import com.monarchsolutions.sms.etl.LegacyPagoRowMapper;
+import com.monarchsolutions.sms.etl.PaymentsLegacyEtlResult;
+import com.monarchsolutions.sms.repository.etl.PaymentsLegacyEtlRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public class PaymentsLegacyEtlService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PaymentsLegacyEtlService.class);
+    private static final String JOB_NAME = "payments";
+    private static final int DEFAULT_PAYMENT_STATUS_ID = 1;
+    private static final LegacyPagoRowMapper LEGACY_PAGO_ROW_MAPPER = new LegacyPagoRowMapper();
+    private static final String LEGACY_PAGOS_QUERY = "SELECT idPago, idAlumno, concepto, monto, fechaRegistro, " +
+            "fechaPago, formaPago, estatusPago, comprobante, observaciones, idUsuarioAprobo, fechaAprobacion " +
+            "FROM pagos WHERE idPago > ? ORDER BY idPago LIMIT ?";
+
+    private final JdbcTemplate legacyJdbcTemplate;
+    private final PaymentsLegacyEtlRepository repository;
+    private final TransactionTemplate transactionTemplate;
+
+    public PaymentsLegacyEtlService(
+            @Qualifier("legacyJdbcTemplate") JdbcTemplate legacyJdbcTemplate,
+            PaymentsLegacyEtlRepository repository,
+            PlatformTransactionManager transactionManager
+    ) {
+        this.legacyJdbcTemplate = legacyJdbcTemplate;
+        this.repository = repository;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    public PaymentsLegacyEtlResult run(String sourceCode, int batchSize) {
+        Instant startedAt = Instant.now();
+        long legacySourceId = repository.findLegacySourceId(sourceCode);
+        long lastPkBefore = repository.getOrCreateWatermark(legacySourceId, JOB_NAME);
+        long etlRunId = repository.createEtlRun(legacySourceId, JOB_NAME, lastPkBefore, startedAt);
+
+        long currentPk = lastPkBefore;
+        long totalRead = 0;
+        long totalInserted = 0;
+        long totalSkipped = 0;
+        long totalIssues = 0;
+        String status = "SUCCESS";
+
+        try {
+            while (true) {
+                List<LegacyPagoRecord> records = legacyJdbcTemplate.query(
+                        LEGACY_PAGOS_QUERY,
+                        LEGACY_PAGO_ROW_MAPPER,
+                        currentPk,
+                        batchSize
+                );
+                if (records.isEmpty()) {
+                    break;
+                }
+                totalRead += records.size();
+                long batchMaxPk = records.get(records.size() - 1).getIdPago();
+
+                BatchOutcome outcome = transactionTemplate.execute(statusTransaction ->
+                        processBatch(legacySourceId, records)
+                );
+                if (outcome == null) {
+                    throw new IllegalStateException("Batch transaction returned null outcome.");
+                }
+
+                totalInserted += outcome.rowsInserted;
+                totalSkipped += outcome.rowsSkipped;
+                totalIssues += outcome.issuesCreated;
+                repository.updateWatermark(legacySourceId, JOB_NAME, batchMaxPk);
+                currentPk = batchMaxPk;
+
+                logger.info(
+                        "Payments legacy ETL batch completed sourceCode={} legacySourceId={} rowsRead={} " +
+                                "rowsInserted={} rowsSkipped={} issuesCreated={} lastLegacyPk={}",
+                        sourceCode,
+                        legacySourceId,
+                        records.size(),
+                        outcome.rowsInserted,
+                        outcome.rowsSkipped,
+                        outcome.issuesCreated,
+                        batchMaxPk
+                );
+
+                if (records.size() < batchSize) {
+                    break;
+                }
+            }
+        } catch (Exception ex) {
+            status = "FAILED";
+            logger.error("Payments legacy ETL failed sourceCode={}", sourceCode, ex);
+            throw ex;
+        } finally {
+            long durationMs = java.time.Duration.between(startedAt, Instant.now()).toMillis();
+            repository.finishEtlRun(
+                    etlRunId,
+                    status,
+                    currentPk,
+                    totalRead,
+                    totalInserted,
+                    totalSkipped,
+                    totalIssues,
+                    durationMs,
+                    Instant.now()
+            );
+        }
+
+        long durationMs = java.time.Duration.between(startedAt, Instant.now()).toMillis();
+        return new PaymentsLegacyEtlResult(
+                lastPkBefore,
+                currentPk,
+                totalRead,
+                totalInserted,
+                totalSkipped,
+                totalIssues,
+                durationMs
+        );
+    }
+
+    private BatchOutcome processBatch(long legacySourceId, List<LegacyPagoRecord> records) {
+        long rowsInserted = 0;
+        long rowsSkipped = 0;
+        long issuesCreated = 0;
+
+        for (LegacyPagoRecord record : records) {
+            try {
+                Optional<Long> studentId = resolveStudentId(legacySourceId, record);
+                if (studentId.isEmpty()) {
+                    rowsSkipped++;
+                    issuesCreated++;
+                    continue;
+                }
+
+                Optional<Long> paymentConceptId = resolvePaymentConceptId(legacySourceId, record);
+                if (paymentConceptId.isEmpty()) {
+                    rowsSkipped++;
+                    issuesCreated++;
+                    continue;
+                }
+
+                PaymentThroughResolution paymentThroughResolution = resolvePaymentThroughId(legacySourceId, record);
+                issuesCreated += paymentThroughResolution.issuesCreated;
+
+                UserResolution userResolution = resolveValidatedByUserId(legacySourceId, record);
+                issuesCreated += userResolution.issuesCreated;
+
+                LocalDateTime createdAt = record.getFechaRegistro() == null
+                        ? LocalDateTime.now()
+                        : LocalDateTime.of(record.getFechaRegistro(), LocalTime.MIDNIGHT);
+                LocalDateTime updatedAt = LocalDateTime.now();
+
+                int updateCount = repository.insertPayment(
+                        studentId.get(),
+                        paymentConceptId.get(),
+                        DEFAULT_PAYMENT_STATUS_ID,
+                        userResolution.userId,
+                        record.getFechaAprobacion(),
+                        createdAt,
+                        updatedAt,
+                        record.getObservaciones(),
+                        paymentThroughResolution.paymentThroughId,
+                        record.getComprobante(),
+                        record.getFechaPago(),
+                        legacySourceId,
+                        record.getIdPago(),
+                        record.getMonto()
+                );
+
+                if (updateCount == 1) {
+                    rowsInserted++;
+                } else {
+                    rowsSkipped++;
+                }
+            } catch (Exception ex) {
+                rowsSkipped++;
+                issuesCreated++;
+                repository.insertMappingIssue(
+                        legacySourceId,
+                        JOB_NAME,
+                        record.getIdPago(),
+                        "PROCESSING_ERROR",
+                        "Unexpected error: " + ex.getMessage()
+                );
+                logger.warn("Payments legacy ETL record failed idPago={}", record.getIdPago(), ex);
+            }
+        }
+
+        return new BatchOutcome(rowsInserted, rowsSkipped, issuesCreated);
+    }
+
+    private Optional<Long> resolveStudentId(long legacySourceId, LegacyPagoRecord record) {
+        if (record.getIdAlumno() == null) {
+            repository.insertMappingIssue(
+                    legacySourceId,
+                    JOB_NAME,
+                    record.getIdPago(),
+                    "MISSING_LEGACY_STUDENT_ID",
+                    "Legacy record missing idAlumno."
+            );
+            return Optional.empty();
+        }
+        Optional<Long> studentId = repository.findStudentId(legacySourceId, record.getIdAlumno());
+        if (studentId.isEmpty()) {
+            repository.insertMappingIssue(
+                    legacySourceId,
+                    JOB_NAME,
+                    record.getIdPago(),
+                    "STUDENT_MAPPING_NOT_FOUND",
+                    "No student_legacy_map match for idAlumno=" + record.getIdAlumno()
+            );
+        }
+        return studentId;
+    }
+
+    private Optional<Long> resolvePaymentConceptId(long legacySourceId, LegacyPagoRecord record) {
+        String normalized = normalizeKey(record.getConcepto());
+        if (normalized == null) {
+            repository.insertMappingIssue(
+                    legacySourceId,
+                    JOB_NAME,
+                    record.getIdPago(),
+                    "MISSING_CONCEPTO",
+                    "Legacy record missing concepto."
+            );
+            return Optional.empty();
+        }
+        Optional<Long> conceptId = repository.findPaymentConceptId(legacySourceId, normalized);
+        if (conceptId.isEmpty()) {
+            repository.insertMappingIssue(
+                    legacySourceId,
+                    JOB_NAME,
+                    record.getIdPago(),
+                    "CONCEPT_MAPPING_NOT_FOUND",
+                    "No payment_concept_legacy_map match for concepto=" + normalized
+            );
+        }
+        return conceptId;
+    }
+
+    private PaymentThroughResolution resolvePaymentThroughId(long legacySourceId, LegacyPagoRecord record) {
+        String normalized = normalizeKey(record.getFormaPago());
+        if (normalized == null) {
+            return new PaymentThroughResolution(null, 0);
+        }
+        Optional<Long> paymentThroughId = repository.findPaymentThroughId(legacySourceId, normalized);
+        if (paymentThroughId.isEmpty()) {
+            repository.insertMappingIssue(
+                    legacySourceId,
+                    JOB_NAME,
+                    record.getIdPago(),
+                    "PAYMENT_THROUGH_MAPPING_NOT_FOUND",
+                    "No payment_through_legacy_map match for formaPago=" + normalized +
+                            ". Proceeding with null payment_through_id."
+            );
+            return new PaymentThroughResolution(null, 1);
+        }
+        return new PaymentThroughResolution(paymentThroughId.get(), 0);
+    }
+
+    private UserResolution resolveValidatedByUserId(long legacySourceId, LegacyPagoRecord record) {
+        if (record.getIdUsuarioAprobo() == null) {
+            return new UserResolution(null, 0);
+        }
+        Optional<Long> mappedUser = repository.findUserIdFromLegacyUserMap(
+                legacySourceId,
+                record.getIdUsuarioAprobo()
+        );
+        if (mappedUser.isPresent()) {
+            return new UserResolution(mappedUser.get(), 0);
+        }
+
+        Optional<String> legacyEmail = findLegacyUserEmail(record.getIdUsuarioAprobo());
+        if (legacyEmail.isEmpty()) {
+            repository.insertMappingIssue(
+                    legacySourceId,
+                    JOB_NAME,
+                    record.getIdPago(),
+                    "LEGACY_USER_EMAIL_NOT_FOUND",
+                    "No legacy email found for idUsuarioAprobo=" + record.getIdUsuarioAprobo()
+            );
+            return new UserResolution(null, 1);
+        }
+
+        Optional<Long> userId = repository.findUserIdByEmail(legacyEmail.get());
+        if (userId.isPresent()) {
+            repository.insertUserLegacyMap(
+                    legacySourceId,
+                    record.getIdUsuarioAprobo(),
+                    legacyEmail.get(),
+                    userId.get()
+            );
+            return new UserResolution(userId.get(), 0);
+        }
+
+        repository.insertMappingIssue(
+                legacySourceId,
+                JOB_NAME,
+                record.getIdPago(),
+                "VALIDATED_USER_NOT_FOUND",
+                "No users match for legacy approver email=" + legacyEmail.get()
+        );
+        return new UserResolution(null, 1);
+    }
+
+    private Optional<String> findLegacyUserEmail(Long legacyUserId) {
+        try {
+            // TODO: Adjust this query to the legacy users/person table as needed for your schema.
+            String email = legacyJdbcTemplate.queryForObject(
+                    "SELECT email FROM usuarios WHERE idUsuario = ?",
+                    String.class,
+                    legacyUserId
+            );
+            return Optional.ofNullable(email);
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private String normalizeKey(String input) {
+        if (input == null) {
+            return null;
+        }
+        String trimmed = input.trim().toLowerCase();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed.replaceAll("\\s+", " ");
+    }
+
+    private static class BatchOutcome {
+        private final long rowsInserted;
+        private final long rowsSkipped;
+        private final long issuesCreated;
+
+        private BatchOutcome(long rowsInserted, long rowsSkipped, long issuesCreated) {
+            this.rowsInserted = rowsInserted;
+            this.rowsSkipped = rowsSkipped;
+            this.issuesCreated = issuesCreated;
+        }
+    }
+
+    private static class PaymentThroughResolution {
+        private final Long paymentThroughId;
+        private final long issuesCreated;
+
+        private PaymentThroughResolution(Long paymentThroughId, long issuesCreated) {
+            this.paymentThroughId = paymentThroughId;
+            this.issuesCreated = issuesCreated;
+        }
+    }
+
+    private static class UserResolution {
+        private final Long userId;
+        private final long issuesCreated;
+
+        private UserResolution(Long userId, long issuesCreated) {
+            this.userId = userId;
+            this.issuesCreated = issuesCreated;
+        }
+    }
+}

--- a/src/main/resources/application-etl-example.yml
+++ b/src/main/resources/application-etl-example.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:mysql://NEW_DB_HOST:3306/edupilot
+    username: NEW_DB_USER
+    password: NEW_DB_PASSWORD
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    legacy:
+      url: jdbc:mysql://LEGACY_DB_HOST:3306/legacy_db
+      username: LEGACY_DB_USER
+      password: LEGACY_DB_PASSWORD
+      driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/db/legacy-payments-etl.sql
+++ b/src/main/resources/db/legacy-payments-etl.sql
@@ -1,0 +1,8 @@
+-- Legacy payments ETL support columns and constraints.
+ALTER TABLE payments
+    ADD COLUMN legacy_source_id INT NULL,
+    ADD COLUMN legacy_payment_id BIGINT NULL;
+
+ALTER TABLE payments
+    ADD CONSTRAINT uq_payments_legacy_source_payment
+        UNIQUE (legacy_source_id, legacy_payment_id);


### PR DESCRIPTION
### Motivation

- Provide a manual, idempotent ETL to migrate only new rows from legacy `pagos` into the new `payments` table while keeping the NEW DB as the primary datasource.
- Enable safe re-runs with watermarking, mapping issue tracking and minimal disruption to production data.
- Allow read-only connections to a remote legacy MySQL using a separate datasource and JDBC template.

### Description

- Add a read-only legacy datasource and `JdbcTemplate` via `LegacyDataSourceConfig` bound to `spring.datasource.legacy` properties and exposed as the bean `legacyJdbcTemplate`.
- Introduce ETL DTOs/RowMapper (`LegacyPagoRecord`, `LegacyPagoRowMapper`) and a result DTO (`PaymentsLegacyEtlResult`).
- Add `PaymentsLegacyEtlRepository` which implements watermark (`etl_watermarks`) and `etl_runs` management, mapping lookups/inserts, mapping issue inserts (`etl_mapping_issues`), and idempotent payment insertion using `ON DUPLICATE KEY UPDATE` into `payments`.
- Implement `PaymentsLegacyEtlService` which pages legacy rows using `SELECT ... FROM pagos WHERE idPago > ? ORDER BY idPago LIMIT ?`, applies normalization (lower-case + trim + collapse spaces), resolves mappings (`student_legacy_map`, `payment_concept_legacy_map`, `payment_through_legacy_map`, `user_legacy_map`), writes mapping issues when needed, inserts new payments transactionally per-batch, and updates the watermark after each successful batch.
- Provide a protected admin endpoint `POST /admin/etl/payments/run?sourceCode=...&batchSize=...` in `PaymentsLegacyEtlController` guarded by `@PreAuthorize("hasRole('ADMIN')")` that runs synchronously and returns a `PaymentsLegacyEtlResult` JSON summary containing `lastLegacyPkBefore`, `lastLegacyPkAfter`, `rowsRead`, `rowsInserted`, `rowsSkipped`, `issuesCreated`, and `durationMs`.
- Add SQL migration snippet `src/main/resources/db/legacy-payments-etl.sql` to add `legacy_source_id` and `legacy_payment_id` columns and a uniqueness constraint on `(legacy_source_id, legacy_payment_id)` to support idempotency.
- Add `src/main/resources/application-etl-example.yml` showing how to configure both new and legacy datasource properties.
- Keep a clear extension point for legacy user-email lookup with a `TODO` comment in `findLegacyUserEmail` so the query can be adjusted for the actual legacy users table.

### Testing

- No automated tests were executed as part of this change.
- The implementation is structured for ease of unit and integration testing (repository methods and `PaymentsLegacyEtlService` boundaries are usefully isolated for mocking `legacyJdbcTemplate` and DB interactions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc16d19948330a27311e3abfe1de1)